### PR TITLE
Import ABC from collections.abc for Python 3.9 compatibility.

### DIFF
--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -2,7 +2,6 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 from os.path import exists, join, dirname, isfile, isdir, abspath, expanduser
 from string import Template
-import collections
 import logging
 import os
 import stat
@@ -14,6 +13,10 @@ try:
     from urllib import quote_plus
 except ImportError:
     from urllib.parse import quote_plus
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 from binstar_client.utils.conda import CONDA_PREFIX, CONDA_ROOT
 from binstar_client.utils.appdirs import AppDirs, EnvAppDirs
@@ -89,7 +92,7 @@ SEARCH_PATH = (
 
 def recursive_update(config, update_dict):
     for update_key, updated_value in update_dict.items():
-        if isinstance(updated_value, collections.Mapping):
+        if isinstance(updated_value, Mapping):
             updated_value_dict = recursive_update(config.get(update_key, {}), updated_value)
             config[update_key] = updated_value_dict
         else:

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 from os.path import exists, join, dirname, isfile, isdir, abspath, expanduser
 from string import Template
+import collections
 import logging
 import os
 import stat


### PR DESCRIPTION
Importing ABC from collections module will raise `ImportError` in Python 3.9 and raises `DeprecationWarning` from 3.4 . Hence use `collections.abc` and also preserve compatibility with Python 2. Ref : https://github.com/python/cpython/pull/10596