### PR TITLE
Wrong PYPI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ conda install anaconda-client
 #### With pip:
 
 ```
-pip install anaconda-client
+pip install anaconda-cli
 ```
 
 #### With pip from source:


### PR DESCRIPTION
It looks like the package has been published as `anaconda-cli` for years.
See https://pypi.org/project/anaconda-cli/
vs
https://pypi.org/project/anaconda-client/