### PR TITLE
Allow errors on rmtree

### DIFF
--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -156,7 +156,7 @@ def inspect_conda_package(filename, *args, **kwargs):  # pylint: disable=unused-
     info_dir = os.path.join(tmpdir, 'info')
     package_data, release_data, file_data = inspect_conda_info_dir(info_dir, os.path.basename(filename))
 
-    rmtree(tmpdir)
+    rmtree(tmpdir, ignore_errors=True)
 
     return package_data, release_data, file_data
 


### PR DESCRIPTION
Getting errors on uploads from GHA:

```
Error:  Trouble reading metadata from C:\Miniconda3\conda-bld\win-64\conda-23.5.0.post1-py39h178df7a_1.conda. Is this a valid conda package?
Error:  
Traceback (most recent call last):
  File "C:\Miniconda3\Scripts\anaconda-script.py", line 9, in <module>
    sys.exit(main())
  File "C:\Miniconda3\lib\site-packages\binstar_client\scripts\cli.py", line 154, in main
    binstar_main(command_module, args, _exit,
  File "C:\Miniconda3\lib\site-packages\binstar_client\scripts\cli.py", line 136, in binstar_main
    return args.main(args)
  File "C:\Miniconda3\lib\site-packages\binstar_client\commands\upload.py", line 339, in main
    package_info = upload_package(
  File "C:\Miniconda3\lib\site-packages\binstar_client\commands\upload.py", line 206, in upload_package
    package_attrs, release_attrs, file_attrs = get_attrs(package_type, filename, parser_args=args)
  File "C:\Miniconda3\lib\site-packages\binstar_client\utils\detect.py", line 153, in get_attrs
    return inspector(filename, fileobj, *args, **kwargs)
  File "C:\Miniconda3\lib\site-packages\binstar_client\inspect_package\conda.py", line 159, in inspect_conda_package
    rmtree(tmpdir)
  File "C:\Miniconda3\lib\shutil.py", line 759, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Miniconda3\lib\shutil.py", line 624, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\Miniconda3\lib\shutil.py", line 629, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\Miniconda3\lib\shutil.py", line 627, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] Access is denied: 'D:\\a\\_temp\\tmplxka0ri1\\info\\about.json'
Failed to upload due to Command '['anaconda', '--quiet', '--show-traceback', '-t', 'D:\\a\\_temp\\XXXX\\XXXXX.token', 'upload', 'C:\\Miniconda3\\conda-bld\\win-64\\conda-23.5.0.post1-py39h178df7a_1.conda', '--user=napari', '--channel=bundle_tools_3', '--force-metadata-update']' returned non-zero exit status 1.. Trying again in 28.722900390625 seconds
```