### PR TITLE
Updated links in upload help text

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -6,12 +6,10 @@
     anaconda upload notebook.ipynb
     anaconda upload environment.yml
 
-##### See Also
+See Also:
 
-  * [Uploading a Conda Package](
-  https://docs.anaconda.com/anaconda-repository/user-guide/tasks/pkgs/use-pkg-managers/#uploading-a-conda-package)
-  * [Uploading a Standard Python Package](
-  https://docs.anaconda.com/anaconda-repository/user-guide/tasks/pkgs/use-pkg-managers/#uploading-pypi-packages)
+* Uploading a Conda Package: https://docs.anaconda.com/free/anacondaorg/user-guide/packages/conda-packages/#cloud-uploading-conda-packages
+* Uploading a Standard Python Package: https://docs.anaconda.com/free/anacondaorg/user-guide/packages/standard-python-packages/#uploading-stdpython-packages
 
 """
 

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -11,7 +11,7 @@ See Also:
 * Uploading a Conda Package: https://docs.anaconda.com/free/anacondaorg/user-guide/packages/conda-packages/#cloud-uploading-conda-packages
 * Uploading a Standard Python Package: https://docs.anaconda.com/free/anacondaorg/user-guide/packages/standard-python-packages/#uploading-stdpython-packages
 
-"""
+"""  # noqa: E501, pylint: disable=line-too-long
 
 from __future__ import annotations
 


### PR DESCRIPTION
I noticed that when running `anaconda upload --help` it would print out a bit of reStructuredText instead of plain output. Turns out it was hardcoded in the docstring of the `upload` command module.

Also fixed the URLs of the links.