### PR TITLE
fix: Manually handle `sys.argv` to allow proper delegation to `binstar_main`

### DIFF
--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -15,6 +15,7 @@ entrypoint in setup.py.
 """
 
 import logging
+import sys
 import warnings
 from argparse import ArgumentParser
 from typing import Any
@@ -98,19 +99,19 @@ def _deprecate(name: str, func: Callable) -> Callable:
         f: The subcommand callable.
 
     """
-    def new_func(ctx: Context) -> Any:
+    def new_func() -> Any:
         msg = (
             f"The existing anaconda-client commands will be deprecated. To maintain compatibility, "
             f"please either pin `anaconda-client<2` or update your system call with the `org` prefix, "
             f'e.g. "anaconda org {name} ..."'
         )
         log.warning(msg)
-        return func(ctx)
+        return func()
 
     return new_func
 
 
-def _subcommand(ctx: Context) -> None:
+def _subcommand() -> None:
     """A common function to use for all subcommands.
 
     In a proper typer/click app, this is the function that is decorated.
@@ -119,11 +120,7 @@ def _subcommand(ctx: Context) -> None:
     to the binstar_main function.
 
     """
-    args = []
-    # Ensure we capture the subcommand name if there is one
-    if ctx.info_name is not None:
-        args.append(ctx.info_name)
-    args.extend(ctx.args)
+    args = [arg for arg in sys.argv[1:] if arg != "org"]
     binstar_main(args, allow_plugin_main=False)
 
 

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -24,7 +24,7 @@ from typing import Callable
 import typer
 import typer.colors
 from anaconda_cli_base.cli import app as main_app
-from typer import Context, Typer
+from typer import Typer
 
 from binstar_client import commands as command_module
 from binstar_client.scripts.cli import (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ pylint~=2.17.4
 pytest~=7.3.1
 pytest-cov~=4.0.0
 pytest-html~=3.2.0
+pytest-mock
 setuptools~=67.8.0
 types-python-dateutil~=2.8.19.13
 types-pytz~=2023.3.0.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
 """Test entrypoint to anaconda-cli-base"""
+# pylint: disable=redefined-outer-name
 import sys
 from importlib import reload
 import logging
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
 from pytest import LogCaptureFixture
@@ -38,18 +39,19 @@ def test_entrypoint() -> None:
 
 @pytest.fixture()
 def assert_binstar_args(mocker):
-    # Returns a closure that can be used to assert that binstar_main was
-    # called with a specific list of args.
-    m = mocker.spy(binstar_client.scripts.cli, "binstar_main")
+    """
+    Returns a closure that can be used to assert that binstar_main was called with a specific list of args.
+    """
+    mock = mocker.spy(binstar_client.scripts.cli, "binstar_main")
 
     def check_args(args):
-        m.assert_called_once_with(commands, args, True)
+        mock.assert_called_once_with(commands, args, True)
 
     return check_args
 
 
 @pytest.mark.parametrize("cmd", sorted(ALL_SUBCOMMANDS))
-def test_org_subcommands(cmd: str, monkeypatch, assert_binstar_args) -> None:
+def test_org_subcommands(cmd: str, monkeypatch: MonkeyPatch, assert_binstar_args: Any) -> None:
     """anaconda org <cmd>"""
 
     args = ["org", cmd, "-h"]
@@ -72,7 +74,7 @@ def test_org_subcommands(cmd: str, monkeypatch, assert_binstar_args) -> None:
 
 
 @pytest.mark.parametrize("cmd", list(HIDDEN_SUBCOMMANDS))
-def test_hidden_commands(cmd: str, monkeypatch, assert_binstar_args) -> None:
+def test_hidden_commands(cmd: str, monkeypatch: MonkeyPatch, assert_binstar_args: Any) -> None:
     """anaconda <cmd>"""
 
     args = [cmd, "-h"]
@@ -93,7 +95,7 @@ def test_hidden_commands(cmd: str, monkeypatch, assert_binstar_args) -> None:
 
 
 @pytest.mark.parametrize("cmd", list(NON_HIDDEN_SUBCOMMANDS))
-def test_non_hidden_commands(cmd: str, monkeypatch, assert_binstar_args) -> None:
+def test_non_hidden_commands(cmd: str, monkeypatch: MonkeyPatch, assert_binstar_args: Any) -> None:
     """anaconda login"""
 
     args = [cmd, "-h"]
@@ -114,7 +116,9 @@ def test_non_hidden_commands(cmd: str, monkeypatch, assert_binstar_args) -> None
 
 
 @pytest.mark.parametrize("cmd", list(DEPRECATED_SUBCOMMANDS))
-def test_deprecated_message(cmd: str, caplog: LogCaptureFixture, monkeypatch, assert_binstar_args) -> None:
+def test_deprecated_message(
+    cmd: str, caplog: LogCaptureFixture, monkeypatch: MonkeyPatch, assert_binstar_args: Any
+) -> None:
     """anaconda <cmd> warning"""
 
     args = [cmd, "-h"]
@@ -130,7 +134,7 @@ def test_deprecated_message(cmd: str, caplog: LogCaptureFixture, monkeypatch, as
 
 
 @pytest.mark.parametrize("cmd", list(NON_HIDDEN_SUBCOMMANDS))
-def test_top_level_options_passed_through(cmd: str, monkeypatch, assert_binstar_args) -> None:
+def test_top_level_options_passed_through(cmd: str, monkeypatch: MonkeyPatch, assert_binstar_args: Any) -> None:
     """Ensure top-level CLI options are passed through to binstar_main."""
 
     args = ["-t", "TOKEN", "-s", "some-site.com", cmd, "-h"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,6 @@ def assert_binstar_args(mocker):
     return check_args
 
 
-
 @pytest.mark.parametrize("cmd", sorted(ALL_SUBCOMMANDS))
 def test_org_subcommands(cmd: str, monkeypatch, assert_binstar_args) -> None:
     """anaconda org <cmd>"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,3 +128,18 @@ def test_deprecated_message(cmd: str, caplog: LogCaptureFixture, monkeypatch, as
         assert "commands will be deprecated" in caplog.records[0].msg
 
     assert_binstar_args([cmd, "-h"])
+
+
+@pytest.mark.parametrize("cmd", list(NON_HIDDEN_SUBCOMMANDS))
+def test_top_level_options_passed_through(cmd: str, monkeypatch, assert_binstar_args) -> None:
+    """Ensure top-level CLI options are passed through to binstar_main."""
+
+    args = ["-t", "TOKEN", "-s", "some-site.com", cmd, "-h"]
+    monkeypatch.setattr(sys, "argv", ["/path/to/anaconda"] + args)
+
+    runner = CliRunner()
+    result = runner.invoke(anaconda_cli_base.cli.app, args)
+    assert result.exit_code == 0
+    assert result.stdout.startswith("usage")
+
+    assert_binstar_args(["-t", "TOKEN", "-s", "some-site.com", cmd, "-h"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 """Test entrypoint to anaconda-cli-base"""
-
+import sys
 from importlib import reload
 import logging
 from typing import Generator
@@ -34,9 +34,15 @@ def test_entrypoint() -> None:
     assert "org" in groups
 
 
-@pytest.mark.parametrize("cmd", ALL_SUBCOMMANDS)
-def test_org_subcommands(cmd: str) -> None:
+# TODO: We should mocker.spy to see what gets passed into binstar_main
+
+
+@pytest.mark.parametrize("cmd", sorted(ALL_SUBCOMMANDS))
+def test_org_subcommands(cmd: str, monkeypatch) -> None:
     """anaconda org <cmd>"""
+
+    args = ["org", cmd, "-h"]
+    monkeypatch.setattr(sys, "argv", ["/path/to/anaconda"] + args)
 
     org = next((group for group in anaconda_cli_base.cli.app.registered_groups if group.name == "org"), None)
     assert org is not None
@@ -47,14 +53,17 @@ def test_org_subcommands(cmd: str) -> None:
     assert subcmd.hidden is False
 
     runner = CliRunner()
-    result = runner.invoke(anaconda_cli_base.cli.app, ["org", cmd, "-h"])
+    result = runner.invoke(anaconda_cli_base.cli.app, args)
     assert result.exit_code == 0
     assert result.stdout.startswith("usage")
 
 
-@pytest.mark.parametrize("cmd", HIDDEN_SUBCOMMANDS)
-def test_hidden_commands(cmd: str) -> None:
+@pytest.mark.parametrize("cmd", list(HIDDEN_SUBCOMMANDS))
+def test_hidden_commands(cmd: str, monkeypatch) -> None:
     """anaconda <cmd>"""
+
+    args = [cmd, "-h"]
+    monkeypatch.setattr(sys, "argv", ["/path/to/anaconda"] + args)
 
     subcmd = next((subcmd for subcmd in anaconda_cli_base.cli.app.registered_commands if subcmd.name == cmd), None)
     assert subcmd is not None
@@ -63,14 +72,17 @@ def test_hidden_commands(cmd: str) -> None:
     assert subcmd.help.startswith("anaconda.org")
 
     runner = CliRunner()
-    result = runner.invoke(anaconda_cli_base.cli.app, [cmd, "-h"])
-    assert result.exit_code == 0
+    result = runner.invoke(anaconda_cli_base.cli.app, args)
+    assert result.exit_code == 0, result.stdout
     assert result.stdout.startswith("usage")
 
 
-@pytest.mark.parametrize("cmd", NON_HIDDEN_SUBCOMMANDS)
-def test_non_hidden_commands(cmd: str) -> None:
+@pytest.mark.parametrize("cmd", list(NON_HIDDEN_SUBCOMMANDS))
+def test_non_hidden_commands(cmd: str, monkeypatch) -> None:
     """anaconda login"""
+
+    args = [cmd, "-h"]
+    monkeypatch.setattr(sys, "argv", ["/path/to/anaconda"] + args)
 
     subcmd = next((subcmd for subcmd in anaconda_cli_base.cli.app.registered_commands if subcmd.name == cmd), None)
     assert subcmd is not None
@@ -79,17 +91,20 @@ def test_non_hidden_commands(cmd: str) -> None:
     assert subcmd.help.startswith("anaconda.org")
 
     runner = CliRunner()
-    result = runner.invoke(anaconda_cli_base.cli.app, [cmd, "-h"])
+    result = runner.invoke(anaconda_cli_base.cli.app, args)
     assert result.exit_code == 0
     assert result.stdout.startswith("usage")
 
 
-@pytest.mark.parametrize("cmd", DEPRECATED_SUBCOMMANDS)
-def test_deprecated_message(cmd: str, caplog: LogCaptureFixture) -> None:
+@pytest.mark.parametrize("cmd", list(DEPRECATED_SUBCOMMANDS))
+def test_deprecated_message(cmd: str, caplog: LogCaptureFixture, monkeypatch) -> None:
     """anaconda <cmd> warning"""
+
+    args = [cmd, "-h"]
+    monkeypatch.setattr(sys, "argv", ["/path/to/anaconda"] + args)
 
     with caplog.at_level(logging.WARNING):
         runner = CliRunner()
-        result = runner.invoke(anaconda_cli_base.cli.app, [cmd, "-h"])
+        result = runner.invoke(anaconda_cli_base.cli.app, args)
         assert result.exit_code == 0
         assert "commands will be deprecated" in caplog.records[0].msg


### PR DESCRIPTION
This PR fixes a bug related to the passing of top-level CLI options into `binstar_main`.

Specifically, when running commands like:
* `anaconda --token TOKEN whoami`
* `anaconda --token TOKEN org whoami`

Since we would like both of those commands to be handled by `binstar_main`, while allowing the top-level entrypoint to be handled by `anaconda-cli-base`, we need some special handling of the top-level options (`--token`, `--site`, etc.).

For now, we just simply pass through `sys.argv` (with the optional `org` subcommand removed). This allows us to have completely backwards-compatible behavior. When we replace subcommands with click/typer-based alternatives, we can pass through these top-level options via the context (`ctx`) object, but for now this solution should be sufficient.


