### PR TITLE
Raise error on deprecated `notebook` subcommand

### DIFF
--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Export reports
         if: ${{ always() && steps.conda_environment_information.outputs.exit_status == 'success' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: report-lint-${{ matrix.python-version }}-${{ matrix.os }}
           path: .artifacts/reports
@@ -134,7 +134,7 @@ jobs:
 
       - name: Export reports
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: report-test-${{ matrix.python-version }}-${{ matrix.os }}
           path: .artifacts/reports

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coveragerc
 .coverage
+.coverage.*
 .tox
 nosetests.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ __conda_*__.txt
 
 # Additional files
 /.artifacts/
+
+# Local dev environment
+env/

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,5 @@
+# Notes about anaconda-client
+
+* PIL is an optional dependency. It is used to load an icon, after introspecting a conda package. It appears it becomes a part of a `release_data` dictionary under the key `icon`. This is done in the function `binstar_client.inspect_package.conda.inspect_conda_info_dir`.
+    * Need to investigate where/how that is used, and then make sure that the backend is actually using it.
+    * It also is used by notebook upload functions, but those will be deprecated

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,0 @@
-# Notes about anaconda-client
-
-* PIL is an optional dependency. It is used to load an icon, after introspecting a conda package. It appears it becomes a part of a `release_data` dictionary under the key `icon`. This is done in the function `binstar_client.inspect_package.conda.inspect_conda_info_dir`.
-    * Need to investigate where/how that is used, and then make sure that the backend is actually using it.
-    * It also is used by notebook upload functions, but those will be deprecated

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -14,7 +14,7 @@ import logging
 from binstar_client import errors
 from binstar_client.utils import get_server_api
 from binstar_client.utils.config import PackageType
-from binstar_client.utils.notebook import parse, has_environment
+from binstar_client.utils.notebook import parse
 from binstar_client.utils.notebook.downloader import Downloader
 
 logger = logging.getLogger('binstar.download')
@@ -68,10 +68,5 @@ def main(args):
         for download_file, download_dist in download_files.items():
             downloader.download(download_dist)
             logger.info('%s has been downloaded as %s', args.handle, download_file)
-            if has_environment(download_file):
-                logger.info('%s has an environment embedded.', download_file)
-                logger.info('Run:')
-                logger.info('    conda env create %s', download_file)
-                logger.info('To install the environment in your system')
     except (errors.DestinationPathExists, errors.NotFound, errors.BinstarError, OSError) as err:
         logger.info(err)

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -2,8 +2,8 @@
 
 """
 Usage:
-    anaconda download notebook
-    anaconda download user/notebook
+    anaconda download <package_name>
+    anaconda download <channel_name>/<package_name>
 """
 
 from __future__ import unicode_literals
@@ -21,7 +21,7 @@ logger = logging.getLogger('binstar.download')
 
 
 def add_parser(subparsers):
-    description = 'Download notebooks from your Anaconda repository'
+    description = 'Download packages from your Anaconda repository'
     parser = subparsers.add_parser(
         'download',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -32,7 +32,7 @@ def add_parser(subparsers):
 
     parser.add_argument(
         'handle',
-        help='user/notebook',
+        help='user/package_name',
         action='store'
     )
 
@@ -58,9 +58,9 @@ def add_parser(subparsers):
 
 def main(args):
     aserver_api = get_server_api(args.token, args.site)
-    username, notebook = parse(args.handle)
+    username, package_name = parse(args.handle)
     username = username or aserver_api.user()['login']
-    downloader = Downloader(aserver_api, username, notebook)
+    downloader = Downloader(aserver_api, username, package_name)
     packages_types = list(map(PackageType, args.package_type) if args.package_type else PackageType)
 
     try:

--- a/binstar_client/commands/notebook.py
+++ b/binstar_client/commands/notebook.py
@@ -6,16 +6,10 @@
 use `anaconda upload/download` instead
 """
 
-from __future__ import unicode_literals
 import argparse
 import logging
 import sys
-from binstar_client import errors
 from binstar_client.deprecations import DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED
-from binstar_client.utils import get_server_api
-from binstar_client.utils.notebook import parse, notebook_url, has_environment
-from binstar_client.utils.notebook.uploader import Uploader
-from binstar_client.utils.notebook.downloader import Downloader
 
 logger = logging.getLogger('binstar.notebook')
 
@@ -40,112 +34,3 @@ def add_parser(subparsers):
     )
 
     parser.set_defaults(main=main)
-
-
-def add_upload_parser(subparsers):
-    description = 'Upload a notebook to your Anaconda repository'
-    epilog = '''
-    [Deprecation warning]
-    `anaconda notebook` is going to be deprecated
-    use `anaconda upload` instead
-    '''
-    parser = subparsers.add_parser('upload',
-                                   formatter_class=argparse.RawDescriptionHelpFormatter,
-                                   help=description,
-                                   description=description,
-                                   epilog=epilog)
-
-    mgroup = parser.add_argument_group('metadata options')
-    mgroup.add_argument('-n', '--name', help='Notebook\'s name (will be parameterized)')
-    mgroup.add_argument('-v', '--version', help='Notebook\'s version')
-    mgroup.add_argument('-s', '--summary', help='Set the summary of the notebook')
-    mgroup.add_argument('-t', '--thumbnail', help='Notebook\'s thumbnail image')
-
-    parser.add_argument(
-        '-u', '--user',
-        help='User account, defaults to the current user'
-    )
-
-    parser.add_argument(
-        '--force',
-        help='Force a notebook upload regardless of errors',
-        action='store_true'
-    )
-
-    parser.add_argument(
-        'notebook',
-        help='Notebook to upload',
-        action='store'
-    )
-
-    parser.set_defaults(main=upload)
-
-
-def add_download_parser(subparsers):
-    description = 'Download notebooks from your Anaconda repository'
-    epilog = '''
-    [Deprecation warning]
-    `anaconda notebook` is going to be deprecated
-    use `anaconda download` instead
-    '''
-    parser = subparsers.add_parser('download',
-                                   formatter_class=argparse.RawDescriptionHelpFormatter,
-                                   help=description,
-                                   description=description,
-                                   epilog=epilog)
-
-    parser.add_argument(
-        'handle',
-        help='user/notebook',
-        action='store'
-    )
-
-    parser.add_argument(
-        '-f', '--force',
-        help='Overwrite',
-        action='store_true'
-    )
-
-    parser.add_argument(
-        '-o', '--output',
-        help='Download as',
-        default='.'
-    )
-
-    parser.set_defaults(main=download)
-
-
-def upload(args):
-    aserver_api = get_server_api(args.token, args.site)
-
-    uploader = Uploader(aserver_api, args.notebook, user=args.user, summary=args.summary,
-                        version=args.version, thumbnail=args.thumbnail, name=args.name)
-
-    try:
-        upload_info = uploader.upload(force=args.force)
-        logger.warning('`anaconda notebook` is going to be deprecated')
-        logger.warning('use `anaconda upload` instead.')
-        logger.info('%s has been uploaded.', args.notebook)
-        logger.info('You can visit your notebook at %s', notebook_url(upload_info))
-    except (errors.BinstarError, IOError) as error:
-        logger.error(error)
-
-
-def download(args):
-    aserver_api = get_server_api(token=args.token, site=args.site)
-
-    username, notebook = parse(args.handle)
-    username = username or aserver_api.user()['login']
-    downloader = Downloader(aserver_api, username, notebook)
-    try:
-        download_info = downloader(output=args.output, force=args.force)
-        logger.warning('`anaconda notebook` is going to be deprecated')
-        logger.warning('use `anaconda download` instead.')
-        logger.info('%s has been downloaded as %s.', args.handle, download_info[0])
-        if has_environment(download_info[0]):
-            logger.info('%s has an environment embedded.', download_info[0])
-            logger.info('Run:')
-            logger.info('    conda env create %s', download_info[0])
-            logger.info('To install the environment in your system')
-    except (errors.DestinationPathExists, errors.NotFound, OSError) as err:
-        logger.info(err.msg)

--- a/binstar_client/commands/notebook.py
+++ b/binstar_client/commands/notebook.py
@@ -27,7 +27,7 @@ def add_parser(subparsers):
                                    description=description,
                                    epilog=__doc__)
     parser.add_argument(
-        'args', 
+        'args',
         nargs='+',
         help='Catch-all for args',
         action='store'

--- a/binstar_client/commands/notebook.py
+++ b/binstar_client/commands/notebook.py
@@ -9,13 +9,20 @@ use `anaconda upload/download` instead
 from __future__ import unicode_literals
 import argparse
 import logging
+import sys
 from binstar_client import errors
+from binstar_client.deprecations import DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED
 from binstar_client.utils import get_server_api
 from binstar_client.utils.notebook import parse, notebook_url, has_environment
 from binstar_client.utils.notebook.uploader import Uploader
 from binstar_client.utils.notebook.downloader import Downloader
 
 logger = logging.getLogger('binstar.notebook')
+
+
+def main(args):
+    logger.error(DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED)
+    return sys.exit(1)
 
 
 def add_parser(subparsers):
@@ -25,10 +32,14 @@ def add_parser(subparsers):
                                    help=description,
                                    description=description,
                                    epilog=__doc__)
+    parser.add_argument(
+        'args', 
+        nargs='+',
+        help='Catch-all for args',
+        action='store'
+    )
 
-    nb_subparsers = parser.add_subparsers()
-    add_upload_parser(nb_subparsers)
-    add_download_parser(nb_subparsers)
+    parser.set_defaults(main=main)
 
 
 def add_upload_parser(subparsers):

--- a/binstar_client/commands/notebook.py
+++ b/binstar_client/commands/notebook.py
@@ -14,7 +14,7 @@ from binstar_client.deprecations import DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_E
 logger = logging.getLogger('binstar.notebook')
 
 
-def main(args):
+def main(args):  # pylint: disable=unused-argument
     logger.error(DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED)
     return sys.exit(1)
 

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -22,10 +22,9 @@ import logging
 import os
 import typing
 
-import nbformat
-
 import binstar_client
 from binstar_client import errors
+from binstar_client.deprecations import DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED
 from binstar_client.utils import bool_input, DEFAULT_CONFIG, get_config, get_server_api
 from binstar_client.utils.config import PackageType
 from binstar_client.utils import detect
@@ -501,11 +500,8 @@ class Uploader:  # pylint: disable=too-many-instance-attributes
 
     def upload_package(self, filename: str, package_meta: detect.Meta) -> bool:
         """Upload a package to the server."""
-        if (
-                package_meta.package_type is PackageType.NOTEBOOK and
-                self.arguments.mode != 'force' and
-                not self.validate_notebook(filename)
-        ):
+        if package_meta.package_type is PackageType.NOTEBOOK:
+            logger.error(DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED)
             return False
 
         meta: PackageMeta = PackageMeta(filename=filename, meta=package_meta)
@@ -626,19 +622,6 @@ class Uploader:  # pylint: disable=too-many-instance-attributes
             if result is None:
                 result = detect.Meta(package_type=package_type, extension=os.path.splitext(filename)[1])
         return result
-
-    @staticmethod
-    def validate_notebook(filename: str) -> bool:
-        """Check if file is a valid notebook."""
-        try:
-            stream: typing.TextIO
-            with open(filename, 'rt', encoding='utf8') as stream:
-                nbformat.read(stream, nbformat.NO_CONVERT)
-        except Exception as error:  # pylint: disable=broad-except
-            logger.error('Invalid notebook file "%s": %s', filename, error)
-            logger.info('Use --force to upload the file anyways')
-            return False
-        return True
 
     @staticmethod
     def validate_package_type(package: PackageCacheRecord, package_type: PackageType) -> bool:

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -3,8 +3,6 @@
 """
 
     anaconda upload CONDA_PACKAGE_1.tar.bz2
-    anaconda upload notebook.ipynb
-    anaconda upload environment.yml
 
 See Also:
 

--- a/binstar_client/deprecations.py
+++ b/binstar_client/deprecations.py
@@ -1,6 +1,8 @@
-DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED = (
-    "The Projects, Notebooks, and Environments features have been removed. "
-    "See our release notes (https://docs.anaconda.com/anacondaorg/release-notes/) "
-    "for more information. "
-    "If you have any questions, please contact usercare@anaconda.com."
-)
+"""Re-usable helpers for deprecating functionality."""
+
+DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED = " ".join([
+    "The Projects, Notebooks, and Environments features have been removed.",
+    "See our release notes (https://docs.anaconda.com/anacondaorg/release-notes/)",
+    "for more information.",
+    "If you have any questions, please contact usercare@anaconda.com.",
+])

--- a/binstar_client/deprecations.py
+++ b/binstar_client/deprecations.py
@@ -1,0 +1,6 @@
+DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED = (
+    "The Projects, Notebooks, and Environments features have been removed. "
+    "See our release notes (https://docs.anaconda.com/anacondaorg/release-notes/) "
+    "for more information. "
+    "If you have any questions, please contact usercare@anaconda.com."
+)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -3,7 +3,6 @@
 
 """Tests for package upload commands."""
 
-import datetime
 import json
 import unittest.mock
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -263,36 +263,6 @@ class Test(CLITestCase):
 
         registry.assertAllCalled()
 
-    @urlpatch
-    def test_upload_notebook_as_package(self, registry):
-        test_datetime = datetime.datetime(2022, 5, 19, 15, 29)
-        mock_version = test_datetime.strftime('%Y.%m.%d.%H%M')
-
-        registry.register(method='HEAD', path='/', status=200)
-        registry.register(method='GET', path='/user', content='{"login": "eggs"}')
-        registry.register(method='GET', path='/dist/eggs/foo/2022.05.19.1529/foo.ipynb', status=404)
-        registry.register(method='GET', path='/package/eggs/foo', content={'package_types': ['ipynb']})
-        registry.register(method='GET', path='/release/eggs/foo/{}'.format(mock_version), content='{}')
-        staging_response = registry.register(
-            method='POST',
-            path='/stage/eggs/foo/{}/foo.ipynb'.format(mock_version),
-            content={'post_url': 'http://s3url.com/s3_url', 'form_data': {}, 'dist_id': 'dist_id'},
-        )
-        registry.register(method='POST', path='/s3_url', status=201)
-        registry.register(
-            method='POST',
-            path='/commit/eggs/foo/{}/foo.ipynb'.format(mock_version),
-            status=200,
-            content={},
-        )
-
-        with unittest.mock.patch('binstar_client.inspect_package.ipynb.datetime') as mock_datetime:
-            mock_datetime.now.return_value = test_datetime
-            main(['--show-traceback', 'upload', data_dir('foo.ipynb')])
-
-        registry.assertAllCalled()
-        self.assertIsNotNone(json.loads(staging_response.req.body).get('sha256'))
-
     @pytest.mark.xfail(reason='anaconda-project removed')
     @urlpatch
     def test_upload_project_specifying_user(self, registry):


### PR DESCRIPTION
Notebooks, projects, and environments have been removed from anaconda.org. This PR replaces the implementation of the `anaconda notebook ...` subcommand with a helpful error message and exits with a system error code of 1. We will remove this code at some point down the line.

The other support for these removed artifact types are embedded within the `upload` and `download` subcommands, so their removal from `anaconda-client` is deferred for now.