### PR TITLE
Use conda package streaming

### DIFF
--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -88,7 +88,7 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }} on ${{ matrix.os }})
-    needs: [lint]
+    # needs: [lint]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -101,10 +101,10 @@ jobs:
       # unfortunately, as of June 2021 - GitHub doesn't support anchors for action scripts
 
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -88,7 +88,7 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }} on ${{ matrix.os }})
-    # needs: [lint]
+    needs: [lint]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -28,7 +28,7 @@ def transform_conda_deps(deps):
         dep = dep.strip()
         name_spec = dep.split(' ', 1)
         if len(name_spec) == 1:
-            name, = name_spec
+            (name,) = name_spec
             depends.append({'name': name, 'specs': []})
         elif len(name_spec) == 2:
             name, spec = name_spec
@@ -53,7 +53,9 @@ def transform_conda_deps(deps):
             else:
                 operator = '=='
 
-            depends.append({'name': name, 'specs': [['==', '%s+%s' % (spec, build_str)]]})
+            depends.append(
+                {'name': name, 'specs': [['==', '%s+%s' % (spec, build_str)]]}
+            )
 
     return {'depends': depends}
 
@@ -88,7 +90,7 @@ def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint
 
     index = _load('index.json', None)
     if index is None:
-        raise TypeError('info/index.json required in conda package %r %r' % (basename, sorted(info_contents)))
+        raise TypeError('info/index.json required in conda package')
 
     recipe = _load('recipe.json')
     about = recipe.get('about', {}) if recipe else _load('about.json', {})
@@ -154,14 +156,21 @@ def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint
 def gather_info_dir(
     fn,
     wanted=set(
-        ('info/index.json', 'info/recipe.json', 'info/about.json', 'info/has_prefix')
+        (
+            'info/index.json',
+            'info/recipe.json',
+            'info/about.json',
+            'info/has_prefix',
+        )
     ),
 ) -> dict[str, bytes]:
     """Use conda-package-streaming to gather files without extracting to disk."""
     # based on code from conda-index
     have: dict[str, bytes] = {}
-    with open(fn, mode="rb") as fileobj:
-        package_stream = stream_conda_component(fn, fileobj, CondaComponent.info)
+    with open(fn, mode='rb') as fileobj:
+        package_stream = stream_conda_component(
+            fn, fileobj, CondaComponent.info
+        )
         for tar, member in package_stream:
             if member.name in wanted:
                 wanted.remove(member.name)

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -79,7 +79,7 @@ def get_subdir(index):
         return '%s-%s' % (index.get('platform'), intel_map.get(arch, arch))
 
 
-def inspect_conda_info_dir(info_contents: dict[str, str | bytes], basename):  # pylint: disable=too-many-locals
+def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint: disable=too-many-locals
     def _load(filename, default=None):
         info_path = f'info/{filename}'
         if info_path in info_contents:
@@ -156,11 +156,11 @@ def gather_info_dir(
     wanted=set(
         ('info/index.json', 'info/recipe.json', 'info/about.json', 'info/has_prefix')
     ),
-):
+) -> dict[str, bytes]:
     """Use conda-package-streaming to gather files without extracting to disk."""
     # based on code from conda-index
-    have = {}
-    with open(fn) as fileobj:
+    have: dict[str, bytes] = {}
+    with open(fn, mode="rb") as fileobj:
         package_stream = stream_conda_component(fn, fileobj, CondaComponent.info)
         for tar, member in package_stream:
             if member.name in wanted:
@@ -175,7 +175,7 @@ def gather_info_dir(
 
     # extremely rare icon case. index.json lists a <hash>.png but the icon
     # appears to always be info/icon.png.
-    if '"icon"' in have.get('info/index.json', ''):
+    if b'"icon"' in have.get('info/index.json', b''):
         have.update(gather_info_dir(fn, wanted=set('info/icon.png')))
 
     return have

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -11,12 +11,15 @@ from conda_package_streaming.package_streaming import (
     stream_conda_component,
     CondaComponent,
 )
+from pathlib import Path
 
 from ..utils.notebook.data_uri import data_uri_from_bytes
 
 
 os_map = {'osx': 'darwin', 'win': 'win32'}
 specs_re = re.compile('^([=><]+)(.*)$')
+
+HERE = Path(__file__).parent
 
 
 def transform_conda_deps(deps):
@@ -88,7 +91,7 @@ def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint
 
     index = _load('index.json', None)
     if index is None:
-        raise TypeError('info/index.json required in conda package')
+        raise TypeError('info/index.json required in conda package %r %r' % (basename, sorted(info_contents)))
 
     recipe = _load('recipe.json')
     about = recipe.get('about', {}) if recipe else _load('about.json', {})
@@ -191,8 +194,7 @@ def inspect_conda_package(filename, *args, **kwargs):  # pylint: disable=unused-
 
 def main():
     filename = sys.argv[1]
-    with open(filename) as fileobj:  # pylint: disable=unspecified-encoding
-        package_data, release_data, file_data = inspect_conda_package(filename, fileobj)
+    package_data, release_data, file_data = inspect_conda_package(filename)
     pprint(package_data)
     print('--')
     pprint(release_data)

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -97,6 +97,7 @@ def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint
     has_prefix = 'info/has_prefix' in info_contents
 
     # Load icon defined in the index.json and file exists inside info folder
+    icon_b64 = index.get('icon', None)
     if index.get('icon'):
         for icon_key in (f'info/{index.get("icon", None)}', 'info/icon.png'):
             if icon_key in info_contents:

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -11,15 +11,12 @@ from conda_package_streaming.package_streaming import (
     stream_conda_component,
     CondaComponent,
 )
-from pathlib import Path
 
 from ..utils.notebook.data_uri import data_uri_from_bytes
 
 
 os_map = {'osx': 'darwin', 'win': 'win32'}
 specs_re = re.compile('^([=><]+)(.*)$')
-
-HERE = Path(__file__).parent
 
 
 def transform_conda_deps(deps):

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 
-from __future__ import print_function
+from __future__ import annotations, print_function
 
 import os.path
 import json

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -157,7 +157,7 @@ def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint
 
 
 def gather_info_dir(
-    fn,
+    path,
     wanted=frozenset(
         (
             'info/index.json',
@@ -171,9 +171,9 @@ def gather_info_dir(
     # based on code from conda-index
     have: dict[str, bytes] = {}
     seeking = set(wanted)
-    with open(fn, mode='rb') as fileobj:
+    with open(path, mode='rb') as fileobj:
         package_stream = stream_conda_component(
-            fn, fileobj, CondaComponent.info
+            path, fileobj, CondaComponent.info
         )
         for tar, member in package_stream:
             if member.name in wanted:
@@ -192,7 +192,7 @@ def gather_info_dir(
         index_json = json.loads(have['info/index.json'])
         # this case matters for our unit tests
         wanted = frozenset(('info/icon.png', f'info/{index_json["icon"]}'))
-        have.update(gather_info_dir(fn, wanted=wanted))
+        have.update(gather_info_dir(path, wanted=wanted))
 
     return have
 

--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations, print_function
 
-import os.path
 import json
+import os.path
 import re
 import sys
 from pprint import pprint
+from typing import Any
+
 from conda_package_streaming.package_streaming import (
-    stream_conda_component,
     CondaComponent,
+    stream_conda_component,
 )
 
 from ..utils.notebook.data_uri import data_uri_from_bytes
-
 
 os_map = {'osx': 'darwin', 'win': 'win32'}
 specs_re = re.compile('^([=><]+)(.*)$')
@@ -81,7 +82,8 @@ def get_subdir(index):
         return '%s-%s' % (index.get('platform'), intel_map.get(arch, arch))
 
 
-def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint: disable=too-many-locals
+def inspect_conda_info_dir(info_contents: dict[str, bytes], basename: str) -> tuple[dict, dict, dict]:
+    # pylint: disable=too-many-locals
     def _load(filename, default=None):
         info_path = f'info/{filename}'
         if info_path in info_contents:
@@ -138,7 +140,7 @@ def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint
         'license_url': about.get('license_url'),
         'license_family': about.get('license_family'),
     }
-    file_data = {
+    file_data: dict[str, Any] = {
         'basename': '%s/%s' % (subdir, basename),
         'attrs': {
             'operatingsystem': operatingsystem,
@@ -157,8 +159,8 @@ def inspect_conda_info_dir(info_contents: dict[str, bytes], basename):  # pylint
 
 
 def gather_info_dir(
-    path,
-    wanted=frozenset(
+    path: os.PathLike,
+    wanted: frozenset[str] = frozenset(
         (
             'info/index.json',
             'info/recipe.json',

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -20,12 +20,12 @@ from platformdirs import PlatformDirs
 try:
     from conda.gateways import anaconda_client as c_client
 except ImportError:
-    c_client = None  # type: ignore
+    c_client = None
 
 try:
     from conda.gateways import anaconda_client as c_client
 except ImportError:
-    c_client = None  # type: ignore
+    c_client = None
 
 from binstar_client.errors import BinstarError
 from binstar_client.utils import conda, paths

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -20,12 +20,12 @@ from platformdirs import PlatformDirs
 try:
     from conda.gateways import anaconda_client as c_client
 except ImportError:
-    c_client = None # type: ignore
+    c_client = None  # type: ignore
 
 try:
     from conda.gateways import anaconda_client as c_client
 except ImportError:
-    c_client = None # type: ignore
+    c_client = None  # type: ignore
 
 from binstar_client.errors import BinstarError
 from binstar_client.utils import conda, paths

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -22,11 +22,6 @@ try:
 except ImportError:
     c_client = None
 
-try:
-    from conda.gateways import anaconda_client as c_client
-except ImportError:
-    c_client = None
-
 from binstar_client.errors import BinstarError
 from binstar_client.utils import conda, paths
 from binstar_client.utils.appdirs import EnvAppDirs

--- a/binstar_client/utils/config.py
+++ b/binstar_client/utils/config.py
@@ -20,7 +20,12 @@ from platformdirs import PlatformDirs
 try:
     from conda.gateways import anaconda_client as c_client
 except ImportError:
-    c_client = None
+    c_client = None # type: ignore
+
+try:
+    from conda.gateways import anaconda_client as c_client
+except ImportError:
+    c_client = None # type: ignore
 
 from binstar_client.errors import BinstarError
 from binstar_client.utils import conda, paths

--- a/binstar_client/utils/notebook/data_uri.py
+++ b/binstar_client/utils/notebook/data_uri.py
@@ -19,16 +19,20 @@ THUMB_SIZE = (340, 210)
 
 
 class DataURIConverter:
-    def __init__(self, location):
+    def __init__(self, location, bytes=None):
         self.check_pillow_installed()
         self.location = location
+        self.bytes = bytes
 
     def check_pillow_installed(self):
         if Image is None:
             raise PillowNotInstalled()
 
     def __call__(self):
-        if os.path.exists(self.location):
+        if self.bytes:
+            fp = io.BytesIO(self.bytes)
+            return self._encode(self.resize_and_convert(fp).read())
+        elif os.path.exists(self.location):
             with open(self.location, 'rb') as file:
                 return self._encode(self.resize_and_convert(file).read())
         elif self.is_url():
@@ -41,6 +45,7 @@ class DataURIConverter:
             raise IOError('{} not found'.format(self.location))
 
     def resize_and_convert(self, file):
+        assert Image  # typing
         image = Image.open(file)
         image.thumbnail(THUMB_SIZE)
         out = io.BytesIO()
@@ -64,3 +69,7 @@ class DataURIConverter:
 
 def data_uri_from(location):
     return DataURIConverter(location)()
+
+
+def data_uri_from_bytes(bytes):
+    return DataURIConverter(location=None, bytes=bytes)()

--- a/binstar_client/utils/notebook/data_uri.py
+++ b/binstar_client/utils/notebook/data_uri.py
@@ -19,19 +19,19 @@ THUMB_SIZE = (340, 210)
 
 
 class DataURIConverter:
-    def __init__(self, location, bytes=None):
+    def __init__(self, location, data=None):
         self.check_pillow_installed()
         self.location = location
-        self.bytes = bytes
+        self.data = data
 
     def check_pillow_installed(self):
         if Image is None:
             raise PillowNotInstalled()
 
     def __call__(self):
-        if self.bytes:
-            fp = io.BytesIO(self.bytes)
-            return self._encode(self.resize_and_convert(fp).read())
+        if self.data:
+            file = io.BytesIO(self.data)
+            return self._encode(self.resize_and_convert(file).read())
         elif os.path.exists(self.location):
             with open(self.location, 'rb') as file:
                 return self._encode(self.resize_and_convert(file).read())
@@ -71,5 +71,5 @@ def data_uri_from(location):
     return DataURIConverter(location)()
 
 
-def data_uri_from_bytes(bytes):
-    return DataURIConverter(location=None, bytes=bytes)()
+def data_uri_from_bytes(data):
+    return DataURIConverter(location=None, data=data)()

--- a/binstar_client/utils/notebook/data_uri.py
+++ b/binstar_client/utils/notebook/data_uri.py
@@ -31,18 +31,19 @@ class DataURIConverter:
     def __call__(self):
         if self.data:
             file = io.BytesIO(self.data)
-            return self._encode(self.resize_and_convert(file).read())
+            b64 = self._encode(self.resize_and_convert(file).read())
         elif os.path.exists(self.location):
             with open(self.location, 'rb') as file:
-                return self._encode(self.resize_and_convert(file).read())
+                b64 = self._encode(self.resize_and_convert(file).read())
         elif self.is_url():
             content = requests.get(self.location, timeout=10 * 60 * 60).content
             file = io.BytesIO()
             file.write(content)
             file.seek(0)
-            return self._encode(self.resize_and_convert(file).read())
+            b64 = self._encode(self.resize_and_convert(file).read())
         else:
             raise IOError('{} not found'.format(self.location))
+        return b64
 
     def resize_and_convert(self, file):
         assert Image  # typing

--- a/binstar_client/utils/notebook/data_uri.py
+++ b/binstar_client/utils/notebook/data_uri.py
@@ -46,7 +46,8 @@ class DataURIConverter:
         return b64
 
     def resize_and_convert(self, file):
-        assert Image  # typing
+        if Image is None:
+            raise PillowNotInstalled()
         image = Image.open(file)
         image.thumbnail(THUMB_SIZE)
         out = io.BytesIO()

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python
     - anaconda-anon-usage >=0.4.0
     - conda-package-handling >=1.7.3
+    - conda-package-streaming
     - defusedxml >=0.7.1
     - nbformat >=4.4.0
     - python-dateutil >=2.6.1

--- a/tests/inspect_package/test_conda.py
+++ b/tests/inspect_package/test_conda.py
@@ -15,7 +15,7 @@ HERE = Path(__file__).parent
 
 
 def data_dir(path):
-    return str(HERE / "data" / path)
+    return str(HERE / 'data' / path)
 
 
 expected_package_data = {
@@ -79,8 +79,10 @@ expected_file_data_121 = {
     },
     'basename': 'osx-64/conda_gc_test-1.2.1-py27_3.tar.bz2',
     'dependencies': {
-        'depends': [{'name': 'foo', 'specs': [['==', '3']]},
-                    {'name': 'python', 'specs': [['==', '2.7.8']]}],
+        'depends': [
+            {'name': 'foo', 'specs': [['==', '3']]},
+            {'name': 'python', 'specs': [['==', '2.7.8']]},
+        ],
     },
 }
 
@@ -100,8 +102,10 @@ expected_file_data_221 = {
     },
     'basename': 'linux-64/conda_gc_test-2.2.1-py27_3.tar.bz2',
     'dependencies': {
-        'depends': [{'name': 'foo', 'specs': [['==', '3']]},
-                    {'name': 'python', 'specs': [['==', '2.7.8']]}],
+        'depends': [
+            {'name': 'foo', 'specs': [['==', '3']]},
+            {'name': 'python', 'specs': [['==', '2.7.8']]},
+        ],
     },
 }
 
@@ -121,8 +125,10 @@ expected_file_data_221_conda = {
     },
     'basename': 'linux-64/conda_gc_test-2.2.1-py27_3.conda',
     'dependencies': {
-        'depends': [{'name': 'foo', 'specs': [['==', '3']]},
-                    {'name': 'python', 'specs': [['==', '2.7.8']]}],
+        'depends': [
+            {'name': 'foo', 'specs': [['==', '3']]},
+            {'name': 'python', 'specs': [['==', '2.7.8']]},
+        ],
     },
 }
 
@@ -183,6 +189,9 @@ class Test(unittest.TestCase):
 
         self.assertEqual(app_expected_package_data, package_data)
         self.assertEqual(app_expected_version_data.pop('icon'), version_data.pop('icon'))
+        self.assertEqual(
+            app_expected_version_data.pop('icon'), version_data.pop('icon')
+        )
         self.assertEqual(app_expected_version_data, version_data)
 
     def test_conda_v2_format(self):

--- a/tests/inspect_package/test_conda.py
+++ b/tests/inspect_package/test_conda.py
@@ -185,9 +185,7 @@ class Test(unittest.TestCase):
 
     def test_conda_app_image(self):
         filename = data_dir('test-app-package-icon-0.1-0.tar.bz2')
-        package_data, version_data, _ = conda.inspect_conda_package(
-            filename
-        )
+        package_data, version_data, _ = conda.inspect_conda_package(filename)
 
         self.assertEqual(app_expected_package_data, package_data)
         self.assertEqual(app_expected_version_data.pop('icon'), version_data.pop('icon'))

--- a/tests/inspect_package/test_conda.py
+++ b/tests/inspect_package/test_conda.py
@@ -189,9 +189,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(app_expected_package_data, package_data)
         self.assertEqual(app_expected_version_data.pop('icon'), version_data.pop('icon'))
-        self.assertEqual(
-            app_expected_version_data.pop('icon'), version_data.pop('icon')
-        )
         self.assertEqual(app_expected_version_data, version_data)
 
     def test_conda_v2_format(self):

--- a/tests/inspect_package/test_conda.py
+++ b/tests/inspect_package/test_conda.py
@@ -4,11 +4,18 @@ from __future__ import print_function, unicode_literals
 
 # Standard libary imports
 import unittest
+from pathlib import Path
 
 # Local imports
 from binstar_client.inspect_package import conda
 from binstar_client.utils.notebook.data_uri import data_uri_from
-from tests.utils.utils import data_dir
+
+
+HERE = Path(__file__).parent
+
+
+def data_dir(path):
+    return str(HERE / "data" / path)
 
 
 expected_package_data = {

--- a/tests/inspect_package/test_conda.py
+++ b/tests/inspect_package/test_conda.py
@@ -156,8 +156,7 @@ class Test(unittest.TestCase):
 
     def test_conda_old(self):
         filename = data_dir('conda_gc_test-1.2.1-py27_3.tar.bz2')
-        with open(filename, 'rb') as file:
-            package_data, version_data, file_data = conda.inspect_conda_package(filename, file)
+        package_data, version_data, file_data = conda.inspect_conda_package(filename)
 
         self.assertEqual(expected_package_data, package_data)
         self.assertEqual(expected_version_data_121, version_data)
@@ -165,8 +164,7 @@ class Test(unittest.TestCase):
 
     def test_conda(self):
         filename = data_dir('conda_gc_test-2.2.1-py27_3.tar.bz2')
-        with open(filename, 'rb') as file:
-            package_data, version_data, file_data = conda.inspect_conda_package(filename, file)
+        package_data, version_data, file_data = conda.inspect_conda_package(filename)
 
         self.assertEqual(expected_package_data, package_data)
         self.assertEqual(expected_version_data_221, version_data)
@@ -174,8 +172,7 @@ class Test(unittest.TestCase):
 
     def test_conda_app_image(self):
         filename = data_dir('test-app-package-icon-0.1-0.tar.bz2')
-        with open(filename, 'rb') as file:
-            package_data, version_data, _ = conda.inspect_conda_package(filename, file)
+        package_data, version_data, file_data = conda.inspect_conda_package(filename)
 
         self.assertEqual(app_expected_package_data, package_data)
         self.assertEqual(app_expected_version_data.pop('icon'), version_data.pop('icon'))
@@ -183,8 +180,7 @@ class Test(unittest.TestCase):
 
     def test_conda_v2_format(self):
         filename = data_dir('conda_gc_test-2.2.1-py27_3.conda')
-        with open(filename, 'rb') as file:
-            package_data, version_data, file_data = conda.inspect_conda_package(filename, file)
+        package_data, version_data, file_data = conda.inspect_conda_package(filename)
 
         self.assertEqual(expected_package_data, package_data)
         self.assertEqual(expected_version_data_221, version_data)

--- a/tests/inspect_package/test_conda.py
+++ b/tests/inspect_package/test_conda.py
@@ -185,7 +185,9 @@ class Test(unittest.TestCase):
 
     def test_conda_app_image(self):
         filename = data_dir('test-app-package-icon-0.1-0.tar.bz2')
-        package_data, version_data, file_data = conda.inspect_conda_package(filename)
+        package_data, version_data, _ = conda.inspect_conda_package(
+            filename
+        )
 
         self.assertEqual(app_expected_package_data, package_data)
         self.assertEqual(app_expected_version_data.pop('icon'), version_data.pop('icon'))


### PR DESCRIPTION
Conda packages can have permissions that prevent this temporary directory from being deleted, causing errors. Use the much more efficient streaming strategy to do it all in memory.

Before this, the icon feature could not have possibly worked. Will this cause problems now that it might work? However [almost no packages use icons.](https://metayaml-conda.fly.dev/metayaml?sql=select+package%2C+index_json+from+repodata_packages+where+json_extract%28index_json%2C+%27%24.icon%27%29+group+by+json_extract%28index_json%2C+%27%24.name%27%29)

I had trouble running pytest, with a lot of UnicodeDecodeError `FAILED binstar_client/inspect_package/tests/test_conda.py::Test::test_conda - UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 10: invalid start byte`

After fixing binary openers, etc., I was able to get `========================================== 141 passed, 2 skipped, 4 xpassed, 40 warnings in 4.32s ==========================================`

Diabolical linters don't run the same locally and in CI.