### PR TITLE
chore: Remove logging hack

### DIFF
--- a/binstar_client/utils/logging_utils.py
+++ b/binstar_client/utils/logging_utils.py
@@ -50,23 +50,6 @@ class ConsoleFormatter(logging.Formatter):
         return super().format(record)
 
 
-try:
-    from rich.logging import RichHandler
-except (ImportError, ModuleNotFoundError):
-    RichHandler = None  # type: ignore
-
-
-def _purge_rich_handler_from_logging_root() -> None:
-    # Remove all handlers associated with the root logger object.
-    # We do this since anaconda-cli-base defines the RichHandler, which conflicts with anaconda-client's logging
-    # We can remove this once we clean up logging.
-    for handler in logging.root.handlers[:]:
-        # Only remove the root RichHandler, and only if rich is installed
-        # This should always happen, but just being super careful here.
-        if RichHandler is not None and isinstance(handler, RichHandler):
-            logging.root.removeHandler(handler)
-
-
 def setup_logging(
         logger: logging.Logger,
         log_level: int = logging.INFO,
@@ -74,7 +57,6 @@ def setup_logging(
         disable_ssl_warnings: bool = False
 ) -> None:
     """Configure logging for the application."""
-    _purge_rich_handler_from_logging_root()
     logger.setLevel(logging.DEBUG)
 
     os.makedirs(config.USER_LOGDIR, exist_ok=True)


### PR DESCRIPTION
We have instead fixed the way logging is initialized inside `anaconda-cli-base` so we no longer need this patch/hack.