### PR TITLE
Improve description for `--keep-basename` option on `anaconda upload` subcommand

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -698,7 +698,10 @@ def add_parser(subparsers: typing.Any) -> None:
     parser.add_argument(
         '--keep-basename',
         dest='keep_basename',
-        help='Do not normalize a basename when uploading a conda package.',
+        help=(
+            'Do not normalize a basename when uploading a conda package. '
+            'Note: this parameter only applies to conda, and not standard Python packages.'
+        ),
         action='store_true'
     )
 


### PR DESCRIPTION
Adds a note to explain that the `--keep-basename` option only applies to conda packages, and not standard Python packages.

Closes #707.