### PR TITLE
Add test to cover parse_specs

### DIFF
--- a/tests/utils/test_parse_specs.py
+++ b/tests/utils/test_parse_specs.py
@@ -1,0 +1,8 @@
+import binstar_client.utils.spec
+def test_parse_specs():
+    spec = binstar_client.utils.spec.parse_specs("bkreider/foo/1.2.3/blah-1.2.3.tar.bz2?x=1")
+    assert spec.user == "bkreider"
+    assert spec.name == "foo"
+    assert spec.version == "1.2.3"
+    assert spec.basename == "blah-1.2.3.tar.bz2"
+    assert spec.attrs == {"x": "1"}

--- a/tests/utils/test_parse_specs.py
+++ b/tests/utils/test_parse_specs.py
@@ -1,4 +1,7 @@
+# pylint: disable=missing-module-docstring,missing-function-docstring
 import binstar_client.utils.spec
+
+
 def test_parse_specs():
     spec = binstar_client.utils.spec.parse_specs("bkreider/foo/1.2.3/blah-1.2.3.tar.bz2?x=1")
     assert spec.user == "bkreider"

--- a/tests/utils/test_spec.py
+++ b/tests/utils/test_spec.py
@@ -4,8 +4,8 @@ import binstar_client.utils.spec
 
 def test_parse_specs():
     # Reproducing for https://github.com/anaconda/anaconda-client/issues/642
-    spec = binstar_client.utils.spec.parse_specs("bkreider/foo/1.2.3/blah-1.2.3.tar.bz2?x=1")
-    assert spec.user == "bkreider"
+    spec = binstar_client.utils.spec.parse_specs("someuser/foo/1.2.3/blah-1.2.3.tar.bz2?x=1")
+    assert spec.user == "someuser"
     assert spec.name == "foo"
     assert spec.version == "1.2.3"
     assert spec.basename == "blah-1.2.3.tar.bz2"

--- a/tests/utils/test_spec.py
+++ b/tests/utils/test_spec.py
@@ -3,6 +3,7 @@ import binstar_client.utils.spec
 
 
 def test_parse_specs():
+    # Reproducing for https://github.com/anaconda/anaconda-client/issues/642
     spec = binstar_client.utils.spec.parse_specs("bkreider/foo/1.2.3/blah-1.2.3.tar.bz2?x=1")
     assert spec.user == "bkreider"
     assert spec.name == "foo"


### PR DESCRIPTION
Adding a test in attempt to reproduce the error in https://github.com/anaconda/anaconda-client/issues/642. It appears the bug was fixed in the past, but it's still valuable to add a small test.

Resolves #642