### PR TITLE
feat: Add optional typer subcommands

### DIFF
--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -127,6 +127,8 @@ jobs:
           conda list --show-channel-urls
 
       - name: Run tests
+        env:
+          _TYPER_FORCE_DISABLE_TERMINAL: 1
         run: |
           mkdir -p .artifacts/reports
           python scripts/refresh_coveragerc.py

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -324,6 +324,12 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--current-info',
             help='Show information about the current authentication token',
         ),
+        remove: typing.List[str] = typer.Option(
+            [],
+            '-r',
+            '--remove',
+            help='Remove authentication tokens. Multiple token names can be provided',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
@@ -334,7 +340,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             list=list_,
             create=create,
             info=info,
-            remove=[],
+            remove=remove,
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -21,6 +21,7 @@ import sys
 import typing
 
 import pytz
+import typer
 from dateutil.parser import parse as parse_date
 
 from binstar_client import errors
@@ -271,3 +272,27 @@ def add_parser(subparsers):
                        action='store_true', help='Show information about the current authentication token')
 
     parser.set_defaults(main=main)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        # no_args_is_help=True,
+    )
+    def auth_subcommand(
+        ctx: typer.Context,
+        name: str = typer.Option(
+            default='',
+            help='A unique name so you can identify this token later. View your tokens at anaconda.org/settings/access'
+        ),
+    ) -> None:
+        args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            name=name,
+        )
+
+        main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring
+# pylint: disable=too-many-arguments
 
 """
 Manage Authentication tokens
@@ -298,12 +299,42 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--organization',
             help='Set the token owner (must be an organization)',
         ),
+        list_scopes: typing.Optional[bool] = typer.Option(
+            False,
+            '-x',
+            '--list-scopes',
+            help='List all authentication scopes',
+        ),
+        list_: typing.Optional[bool] = typer.Option(
+            False,
+            '-l',
+            '--list',
+            help='List all user authentication tokens',
+        ),
+        create: typing.Optional[bool] = typer.Option(
+            False,
+            '-c',
+            '--create',
+            help='Create an authentication token',
+        ),
+        info: typing.Optional[bool] = typer.Option(
+            False,
+            '-i',
+            '--info',
+            '--current-info',
+            help='Show information about the current authentication token',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             name=name_,
             organization=organization,
+            list_scopes=list_scopes,
+            list=list_,
+            create=create,
+            info=info,
+            remove=[],
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -284,15 +284,18 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
     )
     def auth_subcommand(
         ctx: typer.Context,
-        name: str = typer.Option(
-            default='',
+        name_: str = typer.Option(
+            ...,
+            '-n',
+            '--name',
+            default_factory=lambda: f'anaconda_token:{socket.gethostname()}',
             help='A unique name so you can identify this token later. View your tokens at anaconda.org/settings/access'
         ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
-            name=name,
+            name=name_,
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -358,6 +358,9 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
                 'this option multiple times, e.g. --scopes repo --scopes conda:download.'
             ),
         ),
+        out: typing.Optional[typer.FileTextWrite] = typer.Option(
+            sys.stdout,
+        ),
         list_scopes: typing.Optional[bool] = typer.Option(
             False,
             '-x',
@@ -424,6 +427,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             url=url,
             max_age=max_age,
             scopes=scopes,
+            out=out,
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -338,6 +338,10 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--weak',
             help='Create a shorter token',
         ),
+        url: str = typer.Option(
+            'http://anaconda.org',
+            help='The url of the application that will use this token',
+        ),
         list_scopes: typing.Optional[bool] = typer.Option(
             False,
             '-x',
@@ -401,6 +405,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             create=create,
             info=info,
             remove=remove or None,  # The default of None here is to match existing argparse behavior
+            url=url,
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -342,6 +342,10 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             'http://anaconda.org',
             help='The url of the application that will use this token',
         ),
+        max_age: typing.Optional[int] = typer.Option(
+            None,
+            help='The maximum age in seconds that this token will be valid for',
+        ),
         list_scopes: typing.Optional[bool] = typer.Option(
             False,
             '-x',
@@ -406,6 +410,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             info=info,
             remove=remove or None,  # The default of None here is to match existing argparse behavior
             url=url,
+            max_age=max_age,
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -291,11 +291,19 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             default_factory=lambda: f'anaconda_token:{socket.gethostname()}',
             help='A unique name so you can identify this token later. View your tokens at anaconda.org/settings/access'
         ),
+        organization: typing.Optional[str] = typer.Option(
+            None,
+            '-o',
+            '--org',
+            '--organization',
+            help='Set the token owner (must be an organization)',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             name=name_,
+            organization=organization,
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-class-docstring
 # pylint: disable=missing-function-docstring
 # pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
 """
 Manage Authentication tokens
 
@@ -346,6 +347,17 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             None,
             help='The maximum age in seconds that this token will be valid for',
         ),
+        scopes: typing.Optional[typing.List[str]] = typer.Option(
+            [],
+            '-s',
+            '--scopes',
+            help=(
+                'Scopes for token. ' +
+                'For example if you want to limit this token to conda downloads only you would use ' +
+                '--scopes "repo conda:download". You can also provide multiple scopes by providing ' +
+                'this option multiple times, e.g. --scopes repo --scopes conda:download.'
+            ),
+        ),
         list_scopes: typing.Optional[bool] = typer.Option(
             False,
             '-x',
@@ -411,6 +423,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             remove=remove or None,  # The default of None here is to match existing argparse behavior
             url=url,
             max_age=max_age,
+            scopes=scopes,
         )
 
         main(args)

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -297,6 +297,7 @@ def _exclusive_action(ctx: typer.Context, param: typer.CallbackParam, value: str
 
 
 class TokenStrength(Enum):
+    """Available options for strength when creating a token."""
     STRONG = 'strong'
     WEAK = 'weak'
 

--- a/binstar_client/commands/authorizations.py
+++ b/binstar_client/commands/authorizations.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=too-many-arguments
-
 """
 Manage Authentication tokens
 
@@ -275,6 +274,25 @@ def add_parser(subparsers):
     parser.set_defaults(main=main)
 
 
+def _exclusive_action(ctx: typer.Context, param: typer.CallbackParam, value: str) -> str:
+    """Check for exclusivity of action options.
+
+    To do this, we attach a new special attribute onto the typer Context the first time
+    one of the options in the group is used.
+
+    """
+    # pylint: disable=invalid-name
+    # pylint: disable=protected-access
+    if getattr(ctx, '_actions', None) is None:
+        ctx._actions = set()  # type: ignore[attr-defined]
+    if value:
+        if ctx._actions:  # type: ignore[attr-defined]
+            used_action, = ctx._actions  # type: ignore[attr-defined]
+            raise typer.BadParameter(f'mutually exclusive with {used_action}')
+        ctx._actions.add(' / '.join(f"'{o}'" for o in param.opts))  # type: ignore[attr-defined]
+    return value
+
+
 def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
     @app.command(
         name=name,
@@ -304,18 +322,21 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '-x',
             '--list-scopes',
             help='List all authentication scopes',
+            callback=_exclusive_action,
         ),
         list_: typing.Optional[bool] = typer.Option(
             False,
             '-l',
             '--list',
             help='List all user authentication tokens',
+            callback=_exclusive_action,
         ),
         create: typing.Optional[bool] = typer.Option(
             False,
             '-c',
             '--create',
             help='Create an authentication token',
+            callback=_exclusive_action,
         ),
         info: typing.Optional[bool] = typer.Option(
             False,
@@ -323,14 +344,19 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--info',
             '--current-info',
             help='Show information about the current authentication token',
+            callback=_exclusive_action,
         ),
         remove: typing.List[str] = typer.Option(
             [],
             '-r',
             '--remove',
             help='Remove authentication tokens. Multiple token names can be provided',
+            callback=_exclusive_action,
         ),
     ) -> None:
+        if not any([list_scopes, list_, create, info, remove]):
+            raise typer.BadParameter('one of --list-scopes, --list, --list, --info, or --remove must be provided')
+
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),

--- a/binstar_client/commands/channel.py
+++ b/binstar_client/commands/channel.py
@@ -125,6 +125,12 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
     )
     def channel(
         ctx: typer.Context,
+        organization: Optional[str] = typer.Option(
+            None,
+            '-o',
+            '--organization',
+            help='Manage an organizations {}s'.format(name),
+        ),
         copy: Tuple[str, str] = typer.Option(
             ('', ''),
             help=f'Copy a package from one {name} to another',
@@ -135,6 +141,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
+            organization=organization,
             copy=parsed_copy,
         )
 

--- a/binstar_client/commands/channel.py
+++ b/binstar_client/commands/channel.py
@@ -192,6 +192,9 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
     ) -> None:
         # pylint: disable=too-many-arguments
         parsed_copy = _parse_optional_tuple(copy)
+        if not any([parsed_copy, list_, show, lock, unlock, remove]):
+            raise typer.BadParameter('one of --copy, --list, --show, --lock, --unlock, or --remove must be provided')
+
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),

--- a/binstar_client/commands/channel.py
+++ b/binstar_client/commands/channel.py
@@ -136,13 +136,41 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             help=f'Copy a package from one {name} to another',
             show_default=False,
         ),
+        list_: bool = typer.Option(
+            False,
+            '--list',
+            is_flag=True,
+            help=f'List all {name}s for a user',
+        ),
+        show: Optional[str] = typer.Option(
+            None,
+            help=f'Show all of the files in a {name}',
+        ),
+        lock: Optional[str] = typer.Option(
+            None,
+            help=f'Lock a {name}',
+        ),
+        unlock: Optional[str] = typer.Option(
+            None,
+            help=f'Unlock a {name}',
+        ),
+        remove: Optional[str] = typer.Option(
+            None,
+            help=f'Remove a {name}',
+        ),
     ) -> None:
+        # pylint: disable=too-many-arguments
         parsed_copy = _parse_optional_tuple(copy)
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             organization=organization,
             copy=parsed_copy,
+            list=list_,
+            show=show,
+            lock=lock,
+            unlock=unlock,
+            remove=remove,
         )
 
         main(args, name='channel', deprecated=True)

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -1,5 +1,6 @@
 # pylint: disable=fixme
 # pylint: disable=missing-function-docstring
+# pylint: disable=too-many-arguments
 
 """
 anaconda-client configuration
@@ -218,6 +219,20 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             [],
             help='removes a variable',
         ),
+        show: bool = typer.Option(
+            False,
+            help='Show all variables'
+        ),
+        files: bool = typer.Option(
+            False,
+            '-f',
+            '--files',
+            help='show the config file names',
+        ),
+        show_sources: bool = typer.Option(
+            False,
+            help='Display all identified config sources',
+        ),
     ) -> None:
         # There's an existing bug in the type argument for anything but default
         # TODO: Remove the --type option. The below code is what I think was intended, but it's not what happens
@@ -237,9 +252,9 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             set=set_list,
             get=get,
             remove=remove,
-            show=False,
-            files=False,
-            show_sources=False,
+            show=show,
+            files=files,
+            show_sources=show_sources,
             user=True,
         )
 

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -214,6 +214,10 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             None,
             help='get value: name',
         ),
+        remove: List[str] = typer.Option(
+            [],
+            help='removes a variable',
+        ),
     ) -> None:
         # There's an existing bug in the type argument for anything but default
         # TODO: Remove the --type option. The below code is what I think was intended, but it's not what happens
@@ -232,7 +236,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             type=type_func,
             set=set_list,
             get=get,
-            remove=[],
+            remove=remove,
             show=False,
             files=False,
             show_sources=False,

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -68,8 +68,9 @@ from __future__ import print_function
 
 import logging
 from argparse import Namespace, RawDescriptionHelpFormatter
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
+import click
 import typer
 
 from binstar_client.errors import ShowHelp
@@ -203,6 +204,12 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--type',
             help='The type of the values in the set commands'
         ),
+        set_: List[click.Tuple] = typer.Option(
+            [],
+            '--set',
+            help='sets a new variable: name value',
+            click_type=click.Tuple([str, str]),
+        ),
     ) -> None:
         # There's an existing bug in the type argument for anything but default
         # TODO: Remove the --type option. The below code is what I think was intended, but it's not what happens
@@ -212,10 +219,20 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         elif type_ == 'int':
             type_func = int
 
+        # Existing parser is a list of lists, instead of list of tuples
+        set_list = [list(item) for item in set_]  # type: ignore[call-overload]
+
         args = Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             type=type_func,
+            set=set_list,
+            get=None,
+            remove=[],
+            show=False,
+            files=False,
+            show_sources=False,
+            user=True,
         )
 
         main(args)

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -210,6 +210,10 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             help='sets a new variable: name value',
             click_type=click.Tuple([str, str]),
         ),
+        get: Optional[str] = typer.Option(
+            None,
+            help='get value: name',
+        ),
     ) -> None:
         # There's an existing bug in the type argument for anything but default
         # TODO: Remove the --type option. The below code is what I think was intended, but it's not what happens
@@ -227,7 +231,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             site=ctx.obj.params.get('site'),
             type=type_func,
             set=set_list,
-            get=None,
+            get=get,
             remove=[],
             show=False,
             files=False,

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -1,3 +1,4 @@
+# pylint: disable=fixme
 # pylint: disable=missing-function-docstring
 
 """
@@ -66,7 +67,10 @@ If no, then an upload will fail if the package name does not already exist on th
 from __future__ import print_function
 
 import logging
-from argparse import RawDescriptionHelpFormatter
+from argparse import Namespace, RawDescriptionHelpFormatter
+from typing import Callable, Optional
+
+import typer
 
 from binstar_client.errors import ShowHelp
 from binstar_client.utils.config import (SEARCH_PATH, USER_CONFIG, SYSTEM_CONFIG, CONFIGURATION_KEYS,
@@ -182,3 +186,36 @@ def add_parser(subparsers):
                         help='set a variable for all users on this machine')
 
     parser.set_defaults(main=main, sub_parser=parser)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def config_subcommand(
+        ctx: typer.Context,
+        type_: Optional[str] = typer.Option(
+            None,
+            '--type',
+            help='The type of the values in the set commands'
+        ),
+    ) -> None:
+        # There's an existing bug in the type argument for anything but default
+        # TODO: Remove the --type option. The below code is what I think was intended, but it's not what happens
+        type_func: Callable
+        if type_ is None:
+            type_func = safe_load
+        elif type_ == 'int':
+            type_func = int
+
+        args = Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            type=type_func,
+        )
+
+        main(args)

--- a/binstar_client/commands/config.py
+++ b/binstar_client/commands/config.py
@@ -233,6 +233,19 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             False,
             help='Display all identified config sources',
         ),
+        user: Optional[bool] = typer.Option(
+            None,
+            '-u',
+            '--user',
+            help='set a variable for this user',
+        ),
+        system: bool = typer.Option(
+            False,
+            '-s',
+            '--system',
+            '--site',
+            help='set a variable for all users on this machine'
+        )
     ) -> None:
         # There's an existing bug in the type argument for anything but default
         # TODO: Remove the --type option. The below code is what I think was intended, but it's not what happens
@@ -245,6 +258,11 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         # Existing parser is a list of lists, instead of list of tuples
         set_list = [list(item) for item in set_]  # type: ignore[call-overload]
 
+        if user is None:
+            user = True
+        if system:
+            user = False
+
         args = Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
@@ -255,7 +273,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             show=show,
             files=files,
             show_sources=show_sources,
-            user=True,
+            user=user,
         )
 
         main(args)

--- a/binstar_client/commands/copy.py
+++ b/binstar_client/commands/copy.py
@@ -102,6 +102,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         no_args_is_help=True,
     )
     def copy(
+        ctx: typer.Context,
         spec: str = typer.Argument(
             help=(
                 'Package - written as user/package/version[/filename]. '
@@ -133,7 +134,19 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         ),
     ) -> None:
         # pylint: disable=too-many-arguments
+        if ctx.obj.params.get('verbose'):
+            log_level = logging.DEBUG
+        elif ctx.obj.params.get('quiet'):
+            log_level = logging.WARNING
+        else:
+            log_level = logging.INFO
+
         args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            disable_ssl_warnings=ctx.obj.params.get('disable_ssl_warnings'),
+            show_traceback=ctx.obj.params.get('show_traceback'),
+            log_level=log_level,
             spec=spec,
             to_owner=to_owner,
             from_label=from_label,

--- a/binstar_client/commands/copy.py
+++ b/binstar_client/commands/copy.py
@@ -134,19 +134,9 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         ),
     ) -> None:
         # pylint: disable=too-many-arguments
-        if ctx.obj.params.get('verbose'):
-            log_level = logging.DEBUG
-        elif ctx.obj.params.get('quiet'):
-            log_level = logging.WARNING
-        else:
-            log_level = logging.INFO
-
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
-            disable_ssl_warnings=ctx.obj.params.get('disable_ssl_warnings'),
-            show_traceback=ctx.obj.params.get('show_traceback'),
-            log_level=log_level,
             spec=spec,
             to_owner=to_owner,
             from_label=from_label,

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -88,12 +88,16 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         force: bool = typer.Option(
             False, '-f', '--force', help='Overwrite',
         ),
+        output: str = typer.Option(
+            '.', '-o', '--output', help='Download as',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             handle=handle,
             force=force,
+            output=output,
         )
 
         main(args)

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -11,6 +11,8 @@ from __future__ import unicode_literals
 import argparse
 import logging
 
+import typer
+
 from binstar_client import errors
 from binstar_client.utils import get_server_api
 from binstar_client.utils.config import PackageType
@@ -70,3 +72,22 @@ def main(args):
             logger.info('%s has been downloaded as %s', args.handle, download_file)
     except (errors.DestinationPathExists, errors.NotFound, errors.BinstarError, OSError) as err:
         logger.info(err)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def download(
+        ctx: typer.Context,
+    ) -> None:
+        args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+        )
+
+        main(args)

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -84,10 +84,12 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
     )
     def download(
         ctx: typer.Context,
+        handle: str = typer.Argument(help='<channel_name>/<package_name>'),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
+            handle=handle,
         )
 
         main(args)

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 
 import argparse
 import logging
+from typing import List
 
 import typer
 
@@ -75,6 +76,8 @@ def main(args):
 
 
 def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    pkg_types = ', '.join(pkg_type.value for pkg_type in PackageType)
+
     @app.command(
         name=name,
         hidden=hidden,
@@ -91,6 +94,10 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         output: str = typer.Option(
             '.', '-o', '--output', help='Download as',
         ),
+        package_type: List[str] = typer.Option(
+            None, '-t', '--package-type',
+            help='Set the package type [{0}]. Defaults to downloading all package types available'.format(pkg_types),
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
@@ -98,6 +105,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             handle=handle,
             force=force,
             output=output,
+            package_type=package_type or None,
         )
 
         main(args)

--- a/binstar_client/commands/download.py
+++ b/binstar_client/commands/download.py
@@ -85,11 +85,15 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
     def download(
         ctx: typer.Context,
         handle: str = typer.Argument(help='<channel_name>/<package_name>'),
+        force: bool = typer.Option(
+            False, '-f', '--force', help='Overwrite',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             handle=handle,
+            force=force,
         )
 
         main(args)

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -74,6 +74,7 @@ def add_parser(subparsers):
 
 
 class GroupAction(Enum):
+    """Available actions to take on a group."""
     ADD = 'add'
     SHOW = 'show'
     MEMBERS = 'members'
@@ -85,6 +86,7 @@ class GroupAction(Enum):
 
 
 class Permission(Enum):
+    """Available permissions to grant to groups."""
     READ = 'read'
     WRITE = 'write'
     ADMIN = 'admin'

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -95,11 +95,16 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
     def groups_subcommand(
         ctx: typer.Context,
         action: GroupAction = typer.Argument(help='The group management command to execute'),
+        spec: str = typer.Argument(
+            callback=group_spec,
+            help=group_spec.__doc__,
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             action=action.value,
+            spec=spec,
         )
 
         main(args)

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -84,6 +84,12 @@ class GroupAction(Enum):
     REMOVE_PACKAGE = 'remove_package'
 
 
+class Permission(Enum):
+    READ = 'read'
+    WRITE = 'write'
+    ADMIN = 'admin'
+
+
 def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
     @app.command(
         name=name,
@@ -99,12 +105,17 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             callback=group_spec,
             help=group_spec.__doc__,
         ),
+        perms: Permission = typer.Option(
+            'read',
+            help='The permission the group should provide',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             action=action.value,
             spec=spec,
+            perms=perms.value,
         )
 
         main(args)

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -1,8 +1,13 @@
-# pylint: disable=missing-module-docstring,missing-function-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-module-docstring
 
+import argparse
 import logging
-
+from enum import Enum
 from pprint import pformat
+
+import typer
 
 from binstar_client.pprintb import package_list, user_list
 from binstar_client.utils import get_server_api
@@ -66,3 +71,33 @@ def add_parser(subparsers):
                         help='The permission the group should provide')
 
     parser.set_defaults(main=main)
+
+
+class GroupAction(Enum):
+    ADD = 'add'
+    SHOW = 'show'
+    MEMBERS = 'members'
+    ADD_MEMBER = 'add_member'
+    REMOVE_MEMBER = 'remove_member'
+    PACKAGES = 'packages'
+    ADD_PACKAGE = 'add_package'
+    REMOVE_PACKAGE = 'remove_package'
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        # no_args_is_help=True,
+    )
+    def groups_subcommand(
+        ctx: typer.Context,
+    ) -> None:
+        args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+        )
+
+        main(args)

--- a/binstar_client/commands/groups.py
+++ b/binstar_client/commands/groups.py
@@ -90,14 +90,16 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         hidden=hidden,
         help=help_text,
         context_settings=context_settings,
-        # no_args_is_help=True,
+        no_args_is_help=True,
     )
     def groups_subcommand(
         ctx: typer.Context,
+        action: GroupAction = typer.Argument(help='The group management command to execute'),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
+            action=action.value,
         )
 
         main(args)

--- a/binstar_client/commands/move.py
+++ b/binstar_client/commands/move.py
@@ -8,7 +8,10 @@ Move packages between labels.
 
 # Standard library imports
 from __future__ import unicode_literals, print_function
+import argparse
 import logging
+
+import typer
 
 # Local imports
 from binstar_client import errors
@@ -16,6 +19,43 @@ from binstar_client.utils import get_server_api, parse_specs
 
 
 logger = logging.getLogger('binstar.move')
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def move(
+        ctx: typer.Context,
+        spec: str = typer.Argument(
+            help=(
+                'Package - written as user/package/version[/filename]. '
+                'If filename is not given, move all files in the version'
+            ),
+            callback=parse_specs,
+        ),
+        from_label: str = typer.Option(
+            'main',
+            help='Label to move packages from',
+        ),
+        to_label: str = typer.Option(
+            'main',
+            help='Label to move packages to',
+        ),
+    ) -> None:
+        args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            spec=spec,
+            from_label=from_label,
+            to_label=to_label,
+        )
+
+        main(args)
 
 
 def main(args):

--- a/binstar_client/commands/move.py
+++ b/binstar_client/commands/move.py
@@ -21,43 +21,6 @@ from binstar_client.utils import get_server_api, parse_specs
 logger = logging.getLogger('binstar.move')
 
 
-def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
-    @app.command(
-        name=name,
-        hidden=hidden,
-        help=help_text,
-        context_settings=context_settings,
-        no_args_is_help=True,
-    )
-    def move(
-        ctx: typer.Context,
-        spec: str = typer.Argument(
-            help=(
-                'Package - written as user/package/version[/filename]. '
-                'If filename is not given, move all files in the version'
-            ),
-            callback=parse_specs,
-        ),
-        from_label: str = typer.Option(
-            'main',
-            help='Label to move packages from',
-        ),
-        to_label: str = typer.Option(
-            'main',
-            help='Label to move packages to',
-        ),
-    ) -> None:
-        args = argparse.Namespace(
-            token=ctx.obj.params.get('token'),
-            site=ctx.obj.params.get('site'),
-            spec=spec,
-            from_label=from_label,
-            to_label=to_label,
-        )
-
-        main(args)
-
-
 def main(args):
     aserver_api = get_server_api(args.token, args.site)
 
@@ -146,3 +109,40 @@ def add_parser(subparsers):
     )
 
     parser.set_defaults(main=main)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def move(
+        ctx: typer.Context,
+        spec: str = typer.Argument(
+            help=(
+                'Package - written as user/package/version[/filename]. '
+                'If filename is not given, move all files in the version'
+            ),
+            callback=parse_specs,
+        ),
+        from_label: str = typer.Option(
+            'main',
+            help='Label to move packages from',
+        ),
+        to_label: str = typer.Option(
+            'main',
+            help='Label to move packages to',
+        ),
+    ) -> None:
+        args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            spec=spec,
+            from_label=from_label,
+            to_label=to_label,
+        )
+
+        main(args)

--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -72,6 +72,25 @@ def add_parser(subparsers):
     parser.set_defaults(main=main)
 
 
+def _exclusive_action(ctx: typer.Context, param: typer.CallbackParam, value: str) -> str:
+    """Check for exclusivity of action options.
+
+    To do this, we attach a new special attribute onto the typer Context the first time
+    one of the options in the group is used.
+
+    """
+    # pylint: disable=invalid-name
+    # pylint: disable=protected-access
+    if getattr(ctx, '_actions', None) is None:
+        ctx._actions = set()  # type: ignore[attr-defined]
+    if value:
+        if ctx._actions:  # type: ignore[attr-defined]
+            used_action, = ctx._actions  # type: ignore[attr-defined]
+            raise typer.BadParameter(f'mutually exclusive with {used_action}')
+        ctx._actions.add(' / '.join(f"'{o}'" for o in param.opts))  # type: ignore[attr-defined]
+    return value
+
+
 def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
 
     @app.command(
@@ -91,16 +110,22 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         add_collaborator: Optional[str] = typer.Option(
             None,
             help='username of the collaborator you want to add',
+            callback=_exclusive_action,
         ),
         list_collaborators: bool = typer.Option(
             False,
             help='list all of the collaborators in a package',
+            callback=_exclusive_action,
         ),
         create: bool = typer.Option(
             False,
             help='Create a package',
+            callback=_exclusive_action,
         ),
     ) -> None:
+
+        if not any([add_collaborator, list_collaborators, create]):
+            raise typer.BadParameter('one of --add-collaborator, --list-collaborators, or --create must be provided')
 
         args = Namespace(
             token=ctx.obj.params.get('token'),

--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -7,6 +7,9 @@ Anaconda repository package utilities
 from __future__ import print_function
 
 import logging
+from argparse import Namespace
+
+import typer
 
 from binstar_client.utils import get_server_api, parse_specs
 
@@ -66,3 +69,24 @@ def add_parser(subparsers):
                              'This package will require authorized and authenticated access to install'))
 
     parser.set_defaults(main=main)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        # no_args_is_help=True,
+    )
+    def package_subcommand(
+        ctx: typer.Context,
+    ) -> None:
+
+        args = Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+        )
+
+        main(args)

--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -135,10 +135,34 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             None,
             help='Set the package license url',
         ),
+        personal: bool = typer.Option(
+            False,
+            help=(
+                'Set the package access to personal '
+                'This package will be available only on your personal registries'
+            )
+        ),
+        private: bool = typer.Option(
+            False,
+            help=(
+                'Set the package access to private '
+                'This package will require authorized and authenticated access to install'
+            )
+        ),
     ) -> None:
         # pylint: disable=too-many-arguments
         if not any([add_collaborator, list_collaborators, create]):
             raise typer.BadParameter('one of --add-collaborator, --list-collaborators, or --create must be provided')
+
+        if private and personal:
+            raise typer.BadParameter('Cannot set both --private and --personal')
+
+        if private:
+            access = 'private'
+        elif personal:
+            access = 'personal'
+        else:
+            access = None
 
         args = Namespace(
             token=ctx.obj.params.get('token'),
@@ -150,7 +174,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             summary=summary,
             license=license_,
             license_url=license_url,
-            access=None,
+            access=access,
         )
 
         main(args)

--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -122,8 +122,21 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             help='Create a package',
             callback=_exclusive_action,
         ),
+        summary: Optional[str] = typer.Option(
+            None,
+            help='Set the package short summary',
+        ),
+        license_: Optional[str] = typer.Option(
+            None,
+            '--license',
+            help='Set the package license',
+        ),
+        license_url: Optional[str] = typer.Option(
+            None,
+            help='Set the package license url',
+        ),
     ) -> None:
-
+        # pylint: disable=too-many-arguments
         if not any([add_collaborator, list_collaborators, create]):
             raise typer.BadParameter('one of --add-collaborator, --list-collaborators, or --create must be provided')
 
@@ -134,9 +147,9 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             add_collaborator=add_collaborator,
             list_collaborators=list_collaborators,
             create=create,
-            summary=None,
-            license=None,
-            license_url=None,
+            summary=summary,
+            license=license_,
+            license_url=license_url,
             access=None,
         )
 

--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -93,6 +93,13 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             spec=spec,
+            add_collaborator=None,
+            list_collaborators=False,
+            create=False,
+            summary=None,
+            license=None,
+            license_url=None,
+            access=None,
         )
 
         main(args)

--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -78,15 +78,21 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         hidden=hidden,
         help=help_text,
         context_settings=context_settings,
-        # no_args_is_help=True,
+        no_args_is_help=True,
     )
     def package_subcommand(
         ctx: typer.Context,
+        spec: str = typer.Argument(
+            ...,
+            help='Package to operate on',
+            parser=parse_specs,
+        ),
     ) -> None:
 
         args = Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
+            spec=spec,
         )
 
         main(args)

--- a/binstar_client/commands/package.py
+++ b/binstar_client/commands/package.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 
 import logging
 from argparse import Namespace
+from typing import Optional
 
 import typer
 
@@ -87,15 +88,27 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             help='Package to operate on',
             parser=parse_specs,
         ),
+        add_collaborator: Optional[str] = typer.Option(
+            None,
+            help='username of the collaborator you want to add',
+        ),
+        list_collaborators: bool = typer.Option(
+            False,
+            help='list all of the collaborators in a package',
+        ),
+        create: bool = typer.Option(
+            False,
+            help='Create a package',
+        ),
     ) -> None:
 
         args = Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             spec=spec,
-            add_collaborator=None,
-            list_collaborators=False,
-            create=False,
+            add_collaborator=add_collaborator,
+            list_collaborators=list_collaborators,
+            create=create,
             summary=None,
             license=None,
             license_url=None,

--- a/binstar_client/commands/remove.py
+++ b/binstar_client/commands/remove.py
@@ -99,11 +99,18 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             parser=parse_specs,
             help='Package written as USER[/PACKAGE[/VERSION[/FILE]]]'
         ),
+        force: bool = typer.Option(
+            False,
+            '-f',
+            '--force',
+            help='Do not prompt removal',
+        ),
     ) -> None:
         args = Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             specs=specs,
+            force=force,
         )
 
         main(args)

--- a/binstar_client/commands/remove.py
+++ b/binstar_client/commands/remove.py
@@ -10,7 +10,10 @@ example::
 """
 
 import logging
-from argparse import RawTextHelpFormatter
+from argparse import Namespace, RawTextHelpFormatter
+from typing import List
+
+import typer
 
 from binstar_client import errors
 from binstar_client.utils import get_server_api, parse_specs, \
@@ -79,3 +82,28 @@ def add_parser(subparsers):
     )
 
     parser.set_defaults(main=main)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def remove_subcommand(
+        ctx: typer.Context,
+        specs: List[str] = typer.Argument(
+            show_default=False,
+            parser=parse_specs,
+            help='Package written as USER[/PACKAGE[/VERSION[/FILE]]]'
+        ),
+    ) -> None:
+        args = Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            specs=specs,
+        )
+
+        main(args)

--- a/binstar_client/commands/search.py
+++ b/binstar_client/commands/search.py
@@ -60,7 +60,7 @@ def add_parser(subparsers):
 
 
 class Platform(Enum):
-    # pylint: disable=missing-class-docstring
+    """An enum representing platforms that can be passed as options."""
     OSX_32 = 'osx-32'
     OSX_64 = 'osx-64'
     WIN_32 = 'win-32'

--- a/binstar_client/commands/search.py
+++ b/binstar_client/commands/search.py
@@ -6,6 +6,7 @@ Search your Anaconda repository for packages.
 
 import argparse
 import logging
+from enum import Enum
 from typing import Optional
 
 import typer
@@ -58,6 +59,22 @@ def add_parser(subparsers):
     parser.set_defaults(main=search)
 
 
+class Platform(Enum):
+    # pylint: disable=missing-class-docstring
+    OSX_32 = 'osx-32'
+    OSX_64 = 'osx-64'
+    WIN_32 = 'win-32'
+    WIN_64 = 'win-64'
+    LINUX_32 = 'linux-32'
+    LINUX_64 = 'linux-64'
+    LINUX_AARCH64 = 'linux-aarch64'
+    LINUX_ARMV6L = 'linux-armv6l'
+    LINUX_ARMV7L = 'linux-armv7l'
+    LINUX_PPC64LE = 'linux-ppc64le'
+    LINUX_S390X = 'linux-s390x'
+    NOARCH = 'noarch'
+
+
 def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
     @app.command(
         name=name,
@@ -78,7 +95,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--package-type',
             help='Only search for packages of this type',
         ),
-        platform: Optional[str] = typer.Option(
+        platform: Optional[Platform] = typer.Option(
             None,
             '-p',
             '--platform',
@@ -90,7 +107,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             site=ctx.obj.params.get('site'),
             name=[name],
             package_type=package_type,
-            platform=platform,
+            platform=platform.value if platform is not None else None,
         )
 
         search(args)

--- a/binstar_client/commands/search.py
+++ b/binstar_client/commands/search.py
@@ -4,7 +4,11 @@
 Search your Anaconda repository for packages.
 """
 
+import argparse
 import logging
+from typing import Optional
+
+import typer
 
 from binstar_client.utils import config
 from binstar_client.utils import get_server_api
@@ -52,3 +56,41 @@ def add_parser(subparsers):
         help='only search for packages of the chosen platform'
     )
     parser.set_defaults(main=search)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def search_subcommand(
+        ctx: typer.Context,
+        name: str = typer.Argument(
+            help='Search string',
+            show_default=False,
+        ),
+        package_type: Optional[str] = typer.Option(
+            None,
+            '-t',
+            '--package-type',
+            help='Only search for packages of this type',
+        ),
+        platform: Optional[str] = typer.Option(
+            None,
+            '-p',
+            '--platform',
+            help='Only search for packages of the chosen platform',
+        ),
+    ) -> None:
+        args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            name=[name],
+            package_type=package_type,
+            platform=platform,
+        )
+
+        search(args)

--- a/binstar_client/commands/show.py
+++ b/binstar_client/commands/show.py
@@ -12,8 +12,9 @@ Examples:
 """
 
 import logging
+from argparse import Namespace, RawTextHelpFormatter
 
-from argparse import RawTextHelpFormatter
+import typer
 
 from binstar_client.utils import get_server_api, parse_specs
 from binstar_client.utils.config import PackageType
@@ -109,3 +110,28 @@ def add_parser(subparsers):
                         help='Package written as USER[/PACKAGE[/VERSION[/FILE]]]')
 
     parser.set_defaults(main=main)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def show_subcommand(
+        ctx: typer.Context,
+        spec: str = typer.Argument(
+            show_default=False,
+            callback=parse_specs,
+            help='Package written as USER[/PACKAGE[/VERSION[/FILE]]]'
+        ),
+    ) -> None:
+        args = Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            spec=spec,
+        )
+
+        main(args)

--- a/binstar_client/commands/update.py
+++ b/binstar_client/commands/update.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=missing-function-docstring
 
 """Update public attributes of the package or the attributes of the package release."""
 
@@ -12,6 +13,7 @@ import logging
 import os
 import typing
 
+import typer
 import yaml
 
 from binstar_client import errors
@@ -127,3 +129,42 @@ def add_parser(subparsers: typing.Any) -> None:
     )
 
     parser.set_defaults(main=main)
+
+
+def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, context_settings: dict) -> None:
+    @app.command(
+        name=name,
+        hidden=hidden,
+        help=help_text,
+        context_settings=context_settings,
+        no_args_is_help=True,
+    )
+    def update(
+        ctx: typer.Context,
+        spec: str = typer.Argument(
+            help=(
+                'Package - written as user/package/version[/filename]. '
+                'If filename is not given, copy all files in the version'
+            ),
+            show_default=False,
+            callback=parse_specs,
+        ),
+        source: str = typer.Argument(
+            help=(
+                'Path to the file that consists of metadata that will be updated in the destination package. '
+                'It may be a valid package file or `.json` file with described attributes to update'
+            ),
+            show_default=False,
+            callback=file_type,
+        ),
+    ) -> None:
+        args = argparse.Namespace(
+            token=ctx.obj.params.get('token'),
+            site=ctx.obj.params.get('site'),
+            spec=spec,
+            source=source,
+            package_type=None,
+            release=False,
+        )
+
+        main(args)

--- a/binstar_client/commands/update.py
+++ b/binstar_client/commands/update.py
@@ -163,6 +163,10 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             '--package-type',
             help='Set the package type. Defaults to autodetect.',
         ),
+        release: bool = typer.Option(
+            False,
+            help='Use `source` file to update public attributes of the release specified in `spec`',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
@@ -170,7 +174,7 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             spec=spec,
             source=source,
             package_type=package_type,
-            release=False,
+            release=release,
         )
 
         main(args)

--- a/binstar_client/commands/update.py
+++ b/binstar_client/commands/update.py
@@ -157,13 +157,19 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             show_default=False,
             callback=file_type,
         ),
+        package_type: typing.Optional[str] = typer.Option(
+            None,
+            '-t',
+            '--package-type',
+            help='Set the package type. Defaults to autodetect.',
+        ),
     ) -> None:
         args = argparse.Namespace(
             token=ctx.obj.params.get('token'),
             site=ctx.obj.params.get('site'),
             spec=spec,
             source=source,
-            package_type=None,
+            package_type=package_type,
             release=False,
         )
 

--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -830,20 +830,25 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
         hidden=hidden,
         help=help_text,
         context_settings=context_settings,
+        no_args_is_help=True,
     )
     def upload(
         ctx: typer.Context,
         files: typing.List[str] = typer.Argument(),
-        labels: list[str] = typer.Option(
-            [], '-l', '--label',
-            help=label_help.format(deprecation='', label='label'),
-        ),
-        channels: list[str] = typer.Option(
-            [], '-c', '--channel',
+        channels: typing.List[str] = typer.Option(
+            [],
+            '-c',
+            '--channel',
             help=label_help.format(
                 deprecation=typer.style('(deprecated) ', fg=typer.colors.RED, bold=True),
                 label='channel',
             ),
+        ),
+        labels: typing.List[str] = typer.Option(
+            [],
+            '-l',
+            '--label',
+            help=label_help.format(deprecation='', label='label'),
         ),
         progress: bool = typer.Option(True, is_flag=True, help='Show upload progress'),
         user: typing.Optional[str] = typer.Option(
@@ -899,7 +904,6 @@ def mount_subcommand(app: typer.Typer, name: str, hidden: bool, help_text: str, 
             False,
             '-i',
             '--interactive',
-            is_flag=True,
             help='Run an interactive prompt if any packages are missing',
             callback=_exclusive_mode,
         ),

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -27,7 +27,6 @@ import typer
 import typer.colors
 from anaconda_cli_base import console, __version__
 from anaconda_cli_base.cli import app as main_app, ContextExtras
-from typer import Typer
 
 from binstar_client import commands as command_module
 from binstar_client.scripts.cli import (
@@ -101,7 +100,7 @@ SUBCOMMANDS_WITH_NEW_CLI = {
 log = logging.getLogger(__name__)
 warnings.simplefilter("always")
 
-app = Typer(
+app = typer.Typer(
     add_completion=False,
     name="org",
     help="Interact with anaconda.org",

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -81,6 +81,7 @@ SUBCOMMANDS_WITH_NEW_CLI = {
     "copy",
     "label",
     "move",
+    "search",
     "update",
     "upload",
     "whoami",

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -83,6 +83,7 @@ SUBCOMMANDS_WITH_NEW_CLI = {
     "label",
     "move",
     "search",
+    "show",
     "update",
     "upload",
     "whoami",

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -79,6 +79,7 @@ DEPRECATED_SUBCOMMANDS = {
 SUBCOMMANDS_WITH_NEW_CLI = {
     "auth",
     "channel",
+    "config",
     "copy",
     "groups",
     "label",

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -84,6 +84,7 @@ SUBCOMMANDS_WITH_NEW_CLI = {
     "groups",
     "label",
     "move",
+    "package",
     "remove",
     "search",
     "show",

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -34,7 +34,7 @@ from binstar_client.scripts.cli import (
 )
 from binstar_client.utils import logging_utils
 
-logger = logging.getLogger('binstar')
+logger = logging.getLogger("binstar")
 
 # All subcommands in anaconda-client
 ALL_SUBCOMMANDS = {
@@ -160,6 +160,8 @@ def cli_base_main_callback(
     ),
 ) -> None:
     """Anaconda CLI."""
+    # pylint: disable=fixme
+    # pylint: disable=too-many-arguments
     # TODO: This is a temporary copy of the callback defined in anaconda_cli_base.cli.
     #       It is needed because we need to be able to configure the anaconda-client
     #       logger based on CLI arguments, and that must happen at the top-level

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -14,6 +14,7 @@ entrypoint in setup.py.
 
 """
 
+import functools
 import logging
 import os
 import sys
@@ -108,7 +109,6 @@ app = typer.Typer(
 )
 
 
-@main_app.callback(invoke_without_command=True, no_args_is_help=True)
 def cli_base_main_callback(
     ctx: typer.Context,
     token: Optional[str] = typer.Option(
@@ -197,6 +197,12 @@ def cli_base_main_callback(
         show_traceback=ctx.obj.params.get("show_traceback", False),
         disable_ssl_warnings=ctx.obj.params.get("disable_ssl_warnings", False),
     )
+
+
+if not isinstance(main_app, functools.partial):
+    # Don't apply decorator if legacy entrypoint is used
+    decorator = main_app.callback(invoke_without_command=True, no_args_is_help=True)
+    decorator(cli_base_main_callback)
 
 
 @app.callback(invoke_without_command=True, no_args_is_help=True)

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -78,6 +78,7 @@ DEPRECATED_SUBCOMMANDS = {
 # Subcommands which have typer subcommands defined
 SUBCOMMANDS_WITH_NEW_CLI = {
     "copy",
+    "move",
     "upload",
     "whoami",
 }

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -79,6 +79,7 @@ DEPRECATED_SUBCOMMANDS = {
 SUBCOMMANDS_WITH_NEW_CLI = {
     "channel",
     "copy",
+    "groups",
     "label",
     "move",
     "search",

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -81,6 +81,7 @@ SUBCOMMANDS_WITH_NEW_CLI = {
     "channel",
     "config",
     "copy",
+    "download",
     "groups",
     "label",
     "move",

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -81,6 +81,7 @@ SUBCOMMANDS_WITH_NEW_CLI = {
     "copy",
     "label",
     "move",
+    "update",
     "upload",
     "whoami",
 }

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -77,6 +77,7 @@ DEPRECATED_SUBCOMMANDS = {
 }
 # Subcommands which have typer subcommands defined
 SUBCOMMANDS_WITH_NEW_CLI = {
+    "auth",
     "channel",
     "copy",
     "groups",
@@ -246,6 +247,8 @@ def _load_new_subcommand(name: str, help_text: str, app_: Optional[typer.Typer] 
     # This is here to handle the existing deprecation of the channel subcommand
     if name == "label":
         mod_name = "channel"
+    elif name == "auth":
+        mod_name = "authorizations"
     else:
         mod_name = name
     # TODO: More safely check that mount_subcommand exists  # pylint: disable=fixme

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -77,7 +77,9 @@ DEPRECATED_SUBCOMMANDS = {
 }
 # Subcommands which have typer subcommands defined
 SUBCOMMANDS_WITH_NEW_CLI = {
+    "channel",
     "copy",
+    "label",
     "move",
     "upload",
     "whoami",
@@ -236,8 +238,13 @@ def _load_new_subcommand(name: str, help_text: str, app_: Optional[typer.Typer] 
         hidden: If True, the subcommand won't show up in help.
 
     """
-    subcommand_module = getattr(command_module, name)
+    # This is here to handle the existing deprecation of the channel subcommand
+    if name == "label":
+        mod_name = "channel"
+    else:
+        mod_name = name
     # TODO: More safely check that mount_subcommand exists  # pylint: disable=fixme
+    subcommand_module = getattr(command_module, mod_name)
     subcommand_module.mount_subcommand(
         app=app_ or app,
         name=name,

--- a/binstar_client/plugins.py
+++ b/binstar_client/plugins.py
@@ -82,6 +82,7 @@ SUBCOMMANDS_WITH_NEW_CLI = {
     "groups",
     "label",
     "move",
+    "remove",
     "search",
     "show",
     "update",

--- a/binstar_client/utils/spec.py
+++ b/binstar_client/utils/spec.py
@@ -128,6 +128,9 @@ class GroupSpec:
     def __repr__(self):
         return f'<GroupSpec {self.spec_str!r}>'
 
+    def __eq__(self, other):
+        return self.spec_str == other.spec_str
+
     @property
     def org(self):
         if self._org is None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ pylint~=2.17.4
 pytest~=7.3.1
 pytest-cov~=4.0.0
 pytest-html~=3.2.0
-pytest-mock
+pytest-mock~=3.14.0
 setuptools~=67.8.0
 types-python-dateutil~=2.8.19.13
 types-pytz~=2023.3.0.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@
 # pylint: disable=missing-class-docstring
 # pylint: disable=redefined-builtin
 # pylint: disable=redefined-outer-name
+# pylint: disable=too-few-public-methods
 # pylint: disable=use-dict-literal
 
 import shlex
@@ -860,6 +861,11 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
 
     args = ["auth"] + case.args
 
+    class NotNone:
+        # Just a hack to test the out parameter, which I am not actually testing
+        def __eq__(self, other):
+            return other is not None
+
     defaults: Dict[str, Any] = dict(
         token=None,
         site=None,
@@ -875,6 +881,7 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         url="http://anaconda.org",
         max_age=None,
         scopes=[],
+        out=NotNone(),
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -824,6 +824,15 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--organization my-org", dict(organization="my-org"), id="organization-long"),
         CLICase("--org my-org", dict(organization="my-org"), id="organization-mid"),
         CLICase("-o my-org", dict(organization="my-org"), id="organization-short"),
+        CLICase("--list-scopes", dict(list_scopes=True), id="list-scopes-long"),
+        CLICase("-x", dict(list_scopes=True), id="list-scopes-short"),
+        CLICase("--list", dict(list=True), id="list-long"),
+        CLICase("-l", dict(list=True), id="list-short"),
+        CLICase("--create", dict(create=True), id="create-long"),
+        CLICase("-c", dict(create=True), id="create-short"),
+        CLICase("--current-info", dict(info=True), id="info-long"),
+        CLICase("--info", dict(info=True), id="info-mid"),
+        CLICase("-i", dict(info=True), id="info-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -831,11 +840,16 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
 def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     args = ["auth"] + case.args
 
-    defaults = dict(
+    defaults: Dict[str, Any] = dict(
         token=None,
         site=None,
         name=f"anaconda_token:{gethostname()}",
         organization=None,
+        list_scopes=False,
+        list=False,
+        create=False,
+        info=False,
+        remove=[],
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -542,8 +542,13 @@ def test_move_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     "case",
     [
         CLICase("--copy from to", dict(copy=["from", "to"]), id="copy"),
-        CLICase("--list --organization some-org", dict(organization="some-org"), id="organization-long"),
-        CLICase("--list -o some-org", dict(organization="some-org"), id="organization-short"),
+        CLICase("--list --organization some-org", dict(organization="some-org", list=True), id="organization-long"),
+        CLICase("--list -o some-org", dict(organization="some-org", list=True), id="organization-short"),
+        CLICase("--list", dict(list=True), id="list"),
+        CLICase("--show label-name", dict(show="label-name"), id="show"),
+        CLICase("--lock label-name", dict(lock="label-name"), id="lock"),
+        CLICase("--unlock label-name", dict(unlock="label-name"), id="unlock"),
+        CLICase("--remove label-name", dict(remove="label-name"), id="remove"),
     ]
 )
 def test_channel_arg_parsing(subcommand: str, case: CLICase, cli_mocker: InvokerFactory) -> None:
@@ -553,6 +558,11 @@ def test_channel_arg_parsing(subcommand: str, case: CLICase, cli_mocker: Invoker
         site=None,
         organization=None,
         copy=None,
+        list=False,
+        show=None,
+        lock=None,
+        unlock=None,
+        remove=None,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,9 +313,11 @@ def test_top_level_options_passed_through(cmd: str, monkeypatch: MonkeyPatch, as
     ]
 )
 def test_whoami_arg_parsing(
-    prefix_args: List[str], args: List[str], mods: Dict[str, Any], cli_mocker: InvokerFactory
+    prefix_args: List[str], args: List[str], mods: Dict[str, Any], cli_mocker: InvokerFactory, request: FixtureRequest
 ) -> None:
-    args = ["whoami"] + args
+    # This is a bit of a hack but not worth fixing since usage of legacy parser (which doesn't support --at) is temporary
+    at_arg = ["--at", "anaconda.org"] if "orig-bar" not in str(request) else []
+    args = ["whoami"] + at_arg + args
     defaults = dict(
         token=None,
         site=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -717,3 +717,26 @@ def test_arg_parsing_search_command_platform_choice(
 
     mock.assert_main_called_once()
     mock.assert_main_args_contains(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_groups_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    args = ["groups"] + case.args
+    defaults = dict(
+        token=None,
+        site=None,
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.groups.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1063,6 +1063,7 @@ def test_download_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None
     defaults: Dict[str, Any] = dict(
         token=None,
         site=None,
+        handle="handle",
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,6 +615,7 @@ def test_channel_mutually_exclusive_options_required(mocker):
     [
         CLICase(id="defaults"),
         CLICase("--package-type conda", dict(package_type="conda"), id="package-type-long"),
+        CLICase("--release", dict(release=True), id="release"),
         CLICase("-t conda", dict(package_type="conda"), id="package-type-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -930,6 +930,8 @@ def test_auth_mutually_exclusive_options_required(mocker):
 @pytest.mark.parametrize(
     "case",
     [
+        CLICase("--set key value", dict(set=[["key", "value"]]), id="set-single"),
+        CLICase("--set key value --set key2 val2", dict(set=[["key", "value"], ["key2", "val2"]]), id="set-multiple"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -937,9 +939,16 @@ def test_auth_mutually_exclusive_options_required(mocker):
 def test_config_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     args = ["config"] + case.args + ["--type", "int"]
 
-    defaults = dict(
+    defaults: Dict[str, Any] = dict(
         token=None,
         site=None,
+        set=[],
+        get=None,
+        remove=[],
+        show=False,
+        files=False,
+        show_sources=False,
+        user=True,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -722,16 +722,25 @@ def test_arg_parsing_search_command_platform_choice(
 @pytest.mark.parametrize(
     "case",
     [
-        CLICase(id="defaults"),
-        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
-        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+        CLICase(mods=dict(action="add"), id="defaults"),
+        CLICase("add", dict(action="add"), id="action-add"),
+        CLICase("show", dict(action="show"), id="action-show"),
+        CLICase("members", dict(action="members"), id="action-members"),
+        CLICase("add_member", dict(action="add_member"), id="action-add-member"),
+        CLICase("remove_member", dict(action="remove_member"), id="action-remove-member"),
+        CLICase("packages", dict(action="packages"), id="action-packages"),
+        CLICase("add_package", dict(action="add_package"), id="action-add-package"),
+        CLICase("remove_package", dict(action="remove_package"), id="action-remove-package"),
+        CLICase("--token TOKEN", dict(token="TOKEN", action="add"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com", action="add"), id="site", prefix=True),
     ]
 )
 def test_groups_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
-    args = ["groups"] + case.args
+    args = ["groups"] + (case.args or ["add", "some/spec"])
     defaults = dict(
         token=None,
         site=None,
+        action=None,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -932,6 +932,7 @@ def test_auth_mutually_exclusive_options_required(mocker):
     [
         CLICase("--set key value", dict(set=[["key", "value"]]), id="set-single"),
         CLICase("--set key value --set key2 val2", dict(set=[["key", "value"], ["key2", "val2"]]), id="set-multiple"),
+        CLICase("--get key", dict(get="key"), id="get"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -974,13 +974,20 @@ def test_config_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     "case",
     [
         CLICase(id="defaults"),
+        CLICase("--add-collaborator jim", dict(add_collaborator="jim"), id="add-collaborator"),
+        CLICase("--list-collaborators", dict(list_collaborators=True), id="list-collaborators"),
+        CLICase("--create", dict(create=True), id="create"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
 )
 def test_package_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     spec = "user/package"
-    args = ["package"] + case.args + ["--list-collaborators", spec]
+    if not case.args:
+        case.args = ["--list-collaborators"]
+        case.mods["list_collaborators"] = True
+
+    args = ["package"] + case.args + [spec]
 
     defaults: Dict[str, Any] = dict(
         token=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -935,6 +935,9 @@ def test_auth_mutually_exclusive_options_required(mocker):
         CLICase("--get key", dict(get="key"), id="get"),
         CLICase("--remove key", dict(remove=["key"]), id="remove-single"),
         CLICase("--remove key1 --remove key2", dict(remove=["key1", "key2"]), id="remove-multiple"),
+        CLICase("--show", dict(show=True), id="show"),
+        CLICase("--files", dict(files=True), id="files"),
+        CLICase("--show-sources", dict(show_sources=True), id="show-sources"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -782,3 +782,30 @@ def test_show_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     assert result.exit_code == 0, result.stdout
     mock.assert_main_called_once()
     mock.assert_main_args_contains(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    spec_1 = "some-user/some-package/some-version/some-file"
+    spec_2 = "some-user/some-package/some-version/some-other-file"
+    args = ["remove"] + case.args + [spec_1, spec_2]
+
+    defaults = dict(
+        token=None,
+        site=None,
+        specs=[parse_specs(spec_1), parse_specs(spec_2)],
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.remove.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,9 +313,14 @@ def test_top_level_options_passed_through(cmd: str, monkeypatch: MonkeyPatch, as
     ]
 )
 def test_whoami_arg_parsing(
-    prefix_args: List[str], args: List[str], mods: Dict[str, Any], cli_mocker: InvokerFactory, request: FixtureRequest
+    prefix_args: List[str],
+    args: List[str],
+    mods: Dict[str, Any],
+    cli_mocker: InvokerFactory,
+    request: FixtureRequest,
 ) -> None:
-    # This is a bit of a hack but not worth fixing since usage of legacy parser (which doesn't support --at) is temporary
+    # This is a bit of a hack but not worth fixing since usage of legacy parser
+    # (which doesn't support --at) is temporary
     at_arg = ["--at", "anaconda.org"] if "orig-bar" not in str(request) else []
     args = ["whoami"] + at_arg + args
     defaults = dict(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ import logging
 from argparse import Namespace
 from importlib import reload
 from pathlib import Path
+from socket import gethostname
 from typing import Any, Callable, Dict, Generator, List, Optional
 
 import pytest
@@ -818,6 +819,8 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     "case",
     [
         CLICase(id="defaults"),
+        CLICase("--name my-token", dict(name="my-token"), id="name-long"),
+        CLICase("-n my-token", dict(name="my-token"), id="name-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -828,7 +831,7 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     defaults = dict(
         token=None,
         site=None,
-        name="",
+        name=f"anaconda_token:{gethostname()}",
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -912,7 +912,7 @@ def test_auth_mutually_exclusive_options(opts, error_opt, conflict_opt, mocker):
 def test_auth_mutually_exclusive_options_required(mocker):
     mock = mocker.patch("binstar_client.commands.authorizations.main")
 
-    args = ["auth"]
+    args = ["auth", "required-arg"]
     runner = CliRunner()
     result = runner.invoke(anaconda_cli_base.cli.app, args)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -614,6 +614,8 @@ def test_channel_mutually_exclusive_options_required(mocker):
     "case",
     [
         CLICase(id="defaults"),
+        CLICase("--package-type conda", dict(package_type="conda"), id="package-type-long"),
+        CLICase("-t conda", dict(package_type="conda"), id="package-type-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -981,6 +981,8 @@ def test_config_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--summary SUMMARY --create", dict(summary="SUMMARY", create=True), id="summary"),
         CLICase("--license MIT --create", dict(license="MIT", create=True), id="license"),
         CLICase("--license-url license.com --create", dict(license_url="license.com", create=True), id="license-url"),
+        CLICase("--personal --create", dict(access="personal", create=True), id="personal"),
+        CLICase("--private --create", dict(access="private", create=True), id="private"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -978,6 +978,9 @@ def test_config_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--add-collaborator jim", dict(add_collaborator="jim"), id="add-collaborator"),
         CLICase("--list-collaborators", dict(list_collaborators=True), id="list-collaborators"),
         CLICase("--create", dict(create=True), id="create"),
+        CLICase("--summary SUMMARY --create", dict(summary="SUMMARY", create=True), id="summary"),
+        CLICase("--license MIT --create", dict(license="MIT", create=True), id="license"),
+        CLICase("--license-url license.com --create", dict(license_url="license.com", create=True), id="license-url"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -843,6 +843,9 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--create -w", dict(create=True, strength="weak"), id="create-weak-short"),
         CLICase("--create --url some-repo.com", dict(create=True, url="some-repo.com"), id="url"),
         CLICase("--create --max-age 3600", dict(create=True, max_age=3600), id="max-age"),
+        CLICase("--create --scopes repo", dict(create=True, scopes=["repo"]), id="scopes-single-long"),
+        CLICase("--create --scopes repo --scopes conda:download", dict(create=True, scopes=["repo", "conda:download"]), id="scopes-multiple-long"),  # noqa: E501
+        CLICase("--create -s repo -s conda:download", dict(create=True, scopes=["repo", "conda:download"]), id="scopes-multiple-short"),  # noqa: E501
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -871,6 +874,7 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         strength="strong",
         url="http://anaconda.org",
         max_age=None,
+        scopes=[],
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,8 @@ class MockedCliInvoker:
         actual = vars(namespace)
 
         # Now we can assert that the passed args are a superset of some expected dictionary of values
-        assert actual.items() >= expected.items()
+        actual_cmp = {key: val for key, val in actual.items() if key in expected}
+        assert actual_cmp == expected
 
 
 InvokerFactory = Callable[[str], MockedCliInvoker]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -938,6 +938,11 @@ def test_auth_mutually_exclusive_options_required(mocker):
         CLICase("--show", dict(show=True), id="show"),
         CLICase("--files", dict(files=True), id="files"),
         CLICase("--show-sources", dict(show_sources=True), id="show-sources"),
+        CLICase("--user", dict(user=True), id="user-long"),
+        CLICase("-u", dict(user=True), id="user-short"),
+        CLICase("--system", dict(user=False), id="system-long"),
+        CLICase("-s", dict(user=False), id="system-short"),
+        CLICase("--site", dict(user=False), id="site"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -757,3 +757,28 @@ def test_groups_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     assert result.exit_code == 0, result.stdout
     mock.assert_main_called_once()
     mock.assert_main_args_contains(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_show_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    spec = "someone/some-package/some-version"
+    args = ["show"] + case.args + [spec]
+    defaults = dict(
+        token=None,
+        site=None,
+        spec=parse_specs(spec),
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.show.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -788,6 +788,8 @@ def test_show_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     "case",
     [
         CLICase(id="defaults"),
+        CLICase("--force", dict(force=True), id="force-long"),
+        CLICase("-f", dict(force=True), id="force-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -801,6 +803,7 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         token=None,
         site=None,
         specs=[parse_specs(spec_1), parse_specs(spec_2)],
+        force=False,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1057,6 +1057,9 @@ def test_package_mutually_exclusive_options_required(mocker):
         CLICase("-f", dict(force=True), id="force-short"),
         CLICase("--output somewhere", dict(output="somewhere"), id="output-long"),
         CLICase("-o somewhere", dict(output="somewhere"), id="output-short"),
+        CLICase("--package-type conda", dict(package_type=["conda"]), id="package-type-long"),
+        CLICase("-t conda", dict(package_type=["conda"]), id="package-type-short"),
+        CLICase("-t conda -t pypi", dict(package_type=["conda", "pypi"]), id="package-type-multiple"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -1070,6 +1073,7 @@ def test_download_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None
         handle="handle",
         force=False,
         output=".",
+        package_type=None,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -488,12 +488,6 @@ def test_upload_mutually_exclusive_options(opts, error_opt, conflict_opt, mocker
         CLICase("--update", dict(update=True), id="update"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
-        CLICase("--disable-ssl-warnings", dict(disable_ssl_warnings=True), id="disable-ssl-warnings", prefix=True),
-        CLICase("--show-traceback", dict(show_traceback=True), id="show-traceback", prefix=True),
-        CLICase("--verbose", dict(log_level=logging.DEBUG), id="verbose-long", prefix=True),
-        CLICase("-v", dict(log_level=logging.DEBUG), id="verbose-short", prefix=True),
-        CLICase("--quiet", dict(log_level=logging.WARNING), id="quiet-long", prefix=True),
-        CLICase("-q", dict(log_level=logging.WARNING), id="quiet-short", prefix=True),
     ]
 )
 def test_copy_arg_parsing(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1047,3 +1047,27 @@ def test_package_mutually_exclusive_options_required(mocker):
     assert "one of --add-collaborator, --list-collaborators, or --create must be provided" in result.stdout, result.stdout  # noqa: E501
 
     mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_download_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    args = ["download"] + case.args + ["handle"]
+
+    defaults: Dict[str, Any] = dict(
+        token=None,
+        site=None,
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.download.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -503,3 +503,31 @@ def test_copy_arg_parsing(
     assert result.exit_code == 0, result.stdout
     mock.assert_main_called_once()
     mock.assert_main_args_contains(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--from-label source-label", dict(from_label="source-label"), id="from-label"),
+        CLICase("--to-label destination-label", dict(to_label="destination-label"), id="to-label"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_move_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    args = ["move"] + case.args + ["some-spec"]
+    defaults: Dict[str, Any] = dict(
+        token=None,
+        site=None,
+        spec=parse_specs("some-spec"),
+        from_label="main",
+        to_label="main",
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.move.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -542,6 +542,8 @@ def test_move_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     "case",
     [
         CLICase("--copy from to", dict(copy=["from", "to"]), id="copy"),
+        CLICase("--list --organization some-org", dict(organization="some-org"), id="organization-long"),
+        CLICase("--list -o some-org", dict(organization="some-org"), id="organization-short"),
     ]
 )
 def test_channel_arg_parsing(subcommand: str, case: CLICase, cli_mocker: InvokerFactory) -> None:
@@ -549,6 +551,7 @@ def test_channel_arg_parsing(subcommand: str, case: CLICase, cli_mocker: Invoker
     defaults = dict(
         token=None,
         site=None,
+        organization=None,
         copy=None,
     )
     expected = {**defaults, **case.mods}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -836,6 +836,11 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--remove token-1", dict(remove=["token-1"]), id="remove-long-single"),
         CLICase("--remove token-1 token-2", dict(remove=["token-1", "token-2"]), id="remove-long-multiple"),
         CLICase("-r token-1 token-2", dict(remove=["token-1", "token-2"]), id="remove-short-multiple"),
+        CLICase("--create --strength strong", dict(create=True, strength="strong"), id="create-strength-strong"),
+        CLICase("--create --strength weak", dict(create=True, strength="weak"), id="create-strength-weak"),
+        CLICase("--create --strong", dict(create=True, strength="strong"), id="create-strong"),
+        CLICase("--create --weak", dict(create=True, strength="weak"), id="create-weak-long"),
+        CLICase("--create -w", dict(create=True, strength="weak"), id="create-weak-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -855,6 +860,7 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         site=None,
         name=f"binstar_token:{gethostname()}",
         organization=None,
+        strength="strong",
         list_scopes=False,
         list=False,
         create=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -594,3 +594,16 @@ def test_channel_mutually_exclusive_options(opts, error_opt, conflict_opt, mocke
     assert f"Invalid value for {error_opt}: mutually exclusive with {conflict_opt}" in result.stdout, result.stdout
 
     mock.assert_not_called()
+
+
+def test_channel_mutually_exclusive_options_required(mocker):
+    mock = mocker.patch("binstar_client.commands.channel.main")
+
+    runner = CliRunner()
+    args = ["org", "channel", "--organization", "need-some-argument-to-prevent-help"]
+    result = runner.invoke(anaconda_cli_base.cli.app, args)
+
+    assert result.exit_code == 2, result.stdout
+    assert "one of --copy, --list, --show, --lock, --unlock, or --remove must be provided" in result.stdout, result.stdout  # noqa: E501
+
+    mock.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -968,3 +968,28 @@ def test_config_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     assert result.exit_code == 0, result.stdout
     mock.assert_main_called_once()
     mock.assert_main_args_contains(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_package_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    spec = "some/package"
+    args = ["package"] + case.args + ["--list-collaborators", spec]
+
+    defaults: Dict[str, Any] = dict(
+        token=None,
+        site=None,
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.package.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -979,12 +979,13 @@ def test_config_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     ]
 )
 def test_package_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
-    spec = "some/package"
+    spec = "user/package"
     args = ["package"] + case.args + ["--list-collaborators", spec]
 
     defaults: Dict[str, Any] = dict(
         token=None,
         site=None,
+        spec=parse_specs(spec),
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -933,6 +933,8 @@ def test_auth_mutually_exclusive_options_required(mocker):
         CLICase("--set key value", dict(set=[["key", "value"]]), id="set-single"),
         CLICase("--set key value --set key2 val2", dict(set=[["key", "value"], ["key2", "val2"]]), id="set-multiple"),
         CLICase("--get key", dict(get="key"), id="get"),
+        CLICase("--remove key", dict(remove=["key"]), id="remove-single"),
+        CLICase("--remove key1 --remove key2", dict(remove=["key1", "key2"]), id="remove-multiple"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -986,6 +986,13 @@ def test_package_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         token=None,
         site=None,
         spec=parse_specs(spec),
+        add_collaborator=None,
+        list_collaborators=False,
+        create=False,
+        summary=None,
+        license=None,
+        license_url=None,
+        access=None,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -841,6 +841,7 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--create --strong", dict(create=True, strength="strong"), id="create-strong"),
         CLICase("--create --weak", dict(create=True, strength="weak"), id="create-weak-long"),
         CLICase("--create -w", dict(create=True, strength="weak"), id="create-weak-short"),
+        CLICase("--create --url some-repo.com", dict(create=True, url="some-repo.com"), id="url"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -860,12 +861,14 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         site=None,
         name=f"binstar_token:{gethostname()}",
         organization=None,
-        strength="strong",
         list_scopes=False,
         list=False,
         create=False,
         info=expected_info,
         remove=None,
+        # Token creation options
+        strength="strong",
+        url="http://anaconda.org",
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -842,6 +842,7 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--create --weak", dict(create=True, strength="weak"), id="create-weak-long"),
         CLICase("--create -w", dict(create=True, strength="weak"), id="create-weak-short"),
         CLICase("--create --url some-repo.com", dict(create=True, url="some-repo.com"), id="url"),
+        CLICase("--create --max-age 3600", dict(create=True, max_age=3600), id="max-age"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -869,6 +870,7 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         # Token creation options
         strength="strong",
         url="http://anaconda.org",
+        max_age=None,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -812,3 +812,28 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
     assert result.exit_code == 0, result.stdout
     mock.assert_main_called_once()
     mock.assert_main_args_contains(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    args = ["auth"] + case.args
+
+    defaults = dict(
+        token=None,
+        site=None,
+        name="",
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.authorizations.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -925,3 +925,26 @@ def test_auth_mutually_exclusive_options_required(mocker):
     assert "one of --list-scopes, --list, --list, --info, or --remove must be provided" in result.stdout, result.stdout
 
     mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_config_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    args = ["config"] + case.args + ["--type", "int"]
+
+    defaults = dict(
+        token=None,
+        site=None,
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.config.main")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -833,6 +833,9 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--current-info", dict(info=True), id="info-long"),
         CLICase("--info", dict(info=True), id="info-mid"),
         CLICase("-i", dict(info=True), id="info-short"),
+        CLICase("--remove token-1", dict(remove=["token-1"]), id="remove-long-single"),
+        CLICase("--remove token-1 --remove token-2", dict(remove=["token-1", "token-2"]), id="remove-long-multiple"),
+        CLICase("-r token-1 -r token-2", dict(remove=["token-1", "token-2"]), id="remove-short-multiple"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,7 @@ from binstar_client.plugins import (
     SUBCOMMANDS_WITH_NEW_CLI,
 )
 from binstar_client.utils import parse_specs
+from binstar_client.utils.spec import group_spec
 
 BASE_COMMANDS = {"login", "logout", "whoami"}
 HIDDEN_SUBCOMMANDS = ALL_SUBCOMMANDS - BASE_COMMANDS - NON_HIDDEN_SUBCOMMANDS
@@ -736,11 +737,13 @@ def test_arg_parsing_search_command_platform_choice(
     ]
 )
 def test_groups_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
-    args = ["groups"] + (case.args or ["add", "some/spec"])
+    spec = "my-org/my-group/my-member"
+    args = ["groups"] + (case.args or ["add"]) + [spec]
     defaults = dict(
         token=None,
         site=None,
         action=None,
+        spec=group_spec(spec)
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1055,6 +1055,8 @@ def test_package_mutually_exclusive_options_required(mocker):
         CLICase(id="defaults"),
         CLICase("--force", dict(force=True), id="force-long"),
         CLICase("-f", dict(force=True), id="force-short"),
+        CLICase("--output somewhere", dict(output="somewhere"), id="output-long"),
+        CLICase("-o somewhere", dict(output="somewhere"), id="output-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -1067,6 +1069,7 @@ def test_download_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None
         site=None,
         handle="handle",
         force=False,
+        output=".",
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -732,6 +732,9 @@ def test_arg_parsing_search_command_platform_choice(
         CLICase("packages", dict(action="packages"), id="action-packages"),
         CLICase("add_package", dict(action="add_package"), id="action-add-package"),
         CLICase("remove_package", dict(action="remove_package"), id="action-remove-package"),
+        CLICase("--perms read add", dict(perms="read", action="add"), id="perms-read"),
+        CLICase("--perms write add", dict(perms="write", action="add"), id="perms-write"),
+        CLICase("--perms admin add", dict(perms="admin", action="add"), id="perms-admin"),
         CLICase("--token TOKEN", dict(token="TOKEN", action="add"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com", action="add"), id="site", prefix=True),
     ]
@@ -743,7 +746,8 @@ def test_groups_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         token=None,
         site=None,
         action=None,
-        spec=group_spec(spec)
+        spec=group_spec(spec),
+        perms="read",
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -818,12 +818,12 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
 @pytest.mark.parametrize(
     "case",
     [
-        CLICase(id="defaults"),
-        CLICase("--name my-token", dict(name="my-token"), id="name-long"),
-        CLICase("-n my-token", dict(name="my-token"), id="name-short"),
-        CLICase("--organization my-org", dict(organization="my-org"), id="organization-long"),
-        CLICase("--org my-org", dict(organization="my-org"), id="organization-mid"),
-        CLICase("-o my-org", dict(organization="my-org"), id="organization-short"),
+        CLICase("-i", dict(info=True), id="defaults"),
+        CLICase("--name my-token -i", dict(name="my-token", info=True), id="name-long"),
+        CLICase("-n my-token -i", dict(name="my-token", info=True), id="name-short"),
+        CLICase("--organization my-org -i", dict(organization="my-org", info=True), id="organization-long"),
+        CLICase("--org my-org -i", dict(organization="my-org", info=True), id="organization-mid"),
+        CLICase("-o my-org -i", dict(organization="my-org", info=True), id="organization-short"),
         CLICase("--list-scopes", dict(list_scopes=True), id="list-scopes-long"),
         CLICase("-x", dict(list_scopes=True), id="list-scopes-short"),
         CLICase("--list", dict(list=True), id="list-long"),
@@ -834,25 +834,32 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase("--info", dict(info=True), id="info-mid"),
         CLICase("-i", dict(info=True), id="info-short"),
         CLICase("--remove token-1", dict(remove=["token-1"]), id="remove-long-single"),
-        CLICase("--remove token-1 --remove token-2", dict(remove=["token-1", "token-2"]), id="remove-long-multiple"),
-        CLICase("-r token-1 -r token-2", dict(remove=["token-1", "token-2"]), id="remove-short-multiple"),
+        CLICase("--remove token-1 token-2", dict(remove=["token-1", "token-2"]), id="remove-long-multiple"),
+        CLICase("-r token-1 token-2", dict(remove=["token-1", "token-2"]), id="remove-short-multiple"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
 )
 def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    if case.prefix_args:
+        # Need this for the prefix-args tests, since we need an action
+        case.args = ["-i"]
+        expected_info = True
+    else:
+        expected_info = False
+
     args = ["auth"] + case.args
 
     defaults: Dict[str, Any] = dict(
         token=None,
         site=None,
-        name=f"anaconda_token:{gethostname()}",
+        name=f"binstar_token:{gethostname()}",
         organization=None,
         list_scopes=False,
         list=False,
         create=False,
-        info=False,
-        remove=[],
+        info=expected_info,
+        remove=None,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1053,6 +1053,8 @@ def test_package_mutually_exclusive_options_required(mocker):
     "case",
     [
         CLICase(id="defaults"),
+        CLICase("--force", dict(force=True), id="force-long"),
+        CLICase("-f", dict(force=True), id="force-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -1064,6 +1066,7 @@ def test_download_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None
         token=None,
         site=None,
         handle="handle",
+        force=False,
     )
     expected = {**defaults, **case.mods}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,9 @@ from pytest import MonkeyPatch
 from typer import Typer
 from typer import rich_utils
 from typer.testing import CliRunner
+
 import anaconda_cli_base.cli
+
 import binstar_client.plugins
 import binstar_client.scripts.cli
 from binstar_client import commands
@@ -32,8 +34,7 @@ from binstar_client.plugins import (
     DEPRECATED_SUBCOMMANDS,
     SUBCOMMANDS_WITH_NEW_CLI,
 )
-from binstar_client.utils import parse_specs
-from binstar_client.utils.spec import group_spec
+from binstar_client.utils.spec import parse_specs, group_spec
 
 BASE_COMMANDS = {"login", "logout", "whoami"}
 HIDDEN_SUBCOMMANDS = ALL_SUBCOMMANDS - BASE_COMMANDS - NON_HIDDEN_SUBCOMMANDS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -474,6 +474,14 @@ def test_upload_mutually_exclusive_options(opts, error_opt, conflict_opt, mocker
         CLICase("--to-label destination-label", dict(to_label="destination-label"), id="to-label"),
         CLICase("--replace", dict(replace=True), id="replace"),
         CLICase("--update", dict(update=True), id="update"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+        CLICase("--disable-ssl-warnings", dict(disable_ssl_warnings=True), id="disable-ssl-warnings", prefix=True),
+        CLICase("--show-traceback", dict(show_traceback=True), id="show-traceback", prefix=True),
+        CLICase("--verbose", dict(log_level=logging.DEBUG), id="verbose-long", prefix=True),
+        CLICase("-v", dict(log_level=logging.DEBUG), id="verbose-short", prefix=True),
+        CLICase("--quiet", dict(log_level=logging.WARNING), id="quiet-long", prefix=True),
+        CLICase("-q", dict(log_level=logging.WARNING), id="quiet-short", prefix=True),
     ]
 )
 def test_copy_arg_parsing(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -642,3 +642,31 @@ def test_update_arg_parsing(case: CLICase, cli_mocker: InvokerFactory, tmp_path:
     assert result.exit_code == 0, result.stdout
     mock.assert_main_called_once()
     mock.assert_main_args_contains(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        CLICase(id="defaults"),
+        CLICase("--package-type conda", dict(package_type="conda"), id="package-type-long"),
+        CLICase("-t conda", dict(package_type="conda"), id="package-type-short"),
+        CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
+        CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
+    ]
+)
+def test_search_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
+    args = ["search"] + case.args + ["search-term"]
+    defaults = dict(
+        token=None,
+        site=None,
+        name=["search-term"],
+        package_type=None,
+        platform=None,
+    )
+    expected = {**defaults, **case.mods}
+
+    mock = cli_mocker("binstar_client.commands.search.search")
+    result = mock.invoke(args, prefix_args=case.prefix_args)
+    assert result.exit_code == 0, result.stdout
+    mock.assert_main_called_once()
+    mock.assert_main_args_contains(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -821,6 +821,9 @@ def test_remove_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         CLICase(id="defaults"),
         CLICase("--name my-token", dict(name="my-token"), id="name-long"),
         CLICase("-n my-token", dict(name="my-token"), id="name-short"),
+        CLICase("--organization my-org", dict(organization="my-org"), id="organization-long"),
+        CLICase("--org my-org", dict(organization="my-org"), id="organization-mid"),
+        CLICase("-o my-org", dict(organization="my-org"), id="organization-short"),
         CLICase("--token TOKEN", dict(token="TOKEN"), id="token", prefix=True),  # nosec
         CLICase("--site my-site.com", dict(site="my-site.com"), id="site", prefix=True),
     ]
@@ -832,6 +835,7 @@ def test_auth_arg_parsing(case: CLICase, cli_mocker: InvokerFactory) -> None:
         token=None,
         site=None,
         name=f"anaconda_token:{gethostname()}",
+        organization=None,
     )
     expected = {**defaults, **case.mods}
 


### PR DESCRIPTION
## Summary

> Note: these changes were first merged in #723 but were reverted before the 1.13.0 release. This PR is a fresh rebase of the same changes summarized below.

As part of the move toward the typer-based CLI defined in `anaconda-cli-base`, this PR adds a new typer subcommand for each of the existing subcommands. These are only mounted if the `ANACONDA_CLI_FORCE_NEW=true` environment variable is set.

Currently, the default state will either be the legacy CLI (if `anaconda-client` is the only plugin installed, or if `ANACONDA_CLIENT_FORCE_STANDALONE=true`, or to use the light typer subcommand wrapper, which just allows `anaconda-client` to be compatible as a plugin, while delegating all argument parsing and handling to the legacy `argparse` parser.

But, if `ANACONDA_CLI_FORCE_NEW=true`, then all of the subcommands will get handled directly by the typer `@app.command()`'s, which brings a much nicer help screen, and a more modern integration with `anaconda-cli-base`

## Testing strategy

This behavior is intended to be opt-in for now, as a way to gradually roll out and test.

In addition, I have added an extensive set of parametrized tests, covering each of the subcommands and all of their arguments and options. At a top-level, we call the CLI with variations of the environment variable flags to simulate different cases:

1. Disable the typer app and use the legacy CLI directly via `ANACONDA_CLIENT_FORCE_STANDALONE=true`
2. Allow typer to handle the main entrypoint, but use the light wrapper around the CLI: `ANACONDA_CLIENT_FORCE_STANDALONE` and `ANACONDA_CLI_FORCE_NEW` both falsey
3. Use the new subcommands via `ANACONDA_CLI_FORCE_NEW=true`

For each of these cases (which are implemented using a parametrized fixture), we run a large number of parametrized regression tests. The strategy of these tests is:

* Call the subcommand with some arguments
* Monitor the `argparse.Namespace` passed into the associated `main(args)` function for that subcommand
* Ensure that the passed `Namespace` is as-expected. The expected value is a default value, modified by updating with a dictionary of modifications specific to the CLI arguments/options passed in.

Although the thoroughness of the tests introduces time (roughly 1000 parameterizations in total), this should give a high degree of confidence that the new parser will yield the same results as the existing parser.

## Notes

Through this exercise, I discovered some rough edges and possible bugs in the existing parser. For now, these are marked with TODO's and the behavior is matched exactly. However, in some cases, we may want to deprecate or change the legacy behavior in the future. For now, the objective has been to match the existing behavior as closely as possible.