### PR TITLE
chore: Move mypy and pytest settings to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,16 @@ source = "vcs"
 cache_dir = ".cache/mypy"
 ignore_missing_imports = true
 python_version = "3.8"
+
+[tool.pytest.ini_options]
+addopts = [
+  "--durations=10",
+  "--cov=binstar_client",
+  "--cov-report=term-missing",
+  "--color=yes"
+]
+cache_dir = ".cache/pytest"
+# Treat all warnings errors: https://til.simonwillison.net/pytest/treat-warnings-as-errors
+filterwarnings = [
+  "error",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,25 +63,5 @@ source = "vcs"
 
 [tool.mypy]
 cache_dir = ".cache/mypy"
-check_untyped_defs = false
-disallow_any_decorated = false
-disallow_any_explicit = false
-disallow_any_expr = false
-disallow_any_generics = false
-disallow_any_unimported = false
-disallow_incomplete_defs = true
-disallow_subclassing_any = false
-disallow_untyped_calls = false
-disallow_untyped_decorators = false
-disallow_untyped_defs = false
-ignore_errors = false
 ignore_missing_imports = true
-namespace_packages = true
-no_implicit_optional = true
 python_version = "3.8"
-strict_optional = true
-warn_no_return = true
-warn_redundant_casts = true
-warn_return_any = false
-warn_unreachable = true
-warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,28 @@ full = ["requirements-extra.txt"]
 
 [tool.hatch.version]
 source = "vcs"
+
+[tool.mypy]
+cache_dir = ".cache/mypy"
+check_untyped_defs = false
+disallow_any_decorated = false
+disallow_any_explicit = false
+disallow_any_expr = false
+disallow_any_generics = false
+disallow_any_unimported = false
+disallow_incomplete_defs = true
+disallow_subclassing_any = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disallow_untyped_defs = false
+ignore_errors = false
+ignore_missing_imports = true
+namespace_packages = true
+no_implicit_optional = true
+python_version = "3.8"
+strict_optional = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = false
+warn_unreachable = true
+warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,10 @@ python_version = "3.8"
 
 [tool.pytest.ini_options]
 addopts = [
-  "--durations=10",
+  "--color=yes",
   "--cov=binstar_client",
   "--cov-report=term-missing",
-  "--color=yes"
+  "--durations=10",
 ]
 cache_dir = ".cache/pytest"
 # Treat all warnings errors: https://til.simonwillison.net/pytest/treat-warnings-as-errors

--- a/setup.cfg
+++ b/setup.cfg
@@ -147,10 +147,3 @@ dummy-variables-rgx=^_+$|^_[a-zA-Z0-9_]*[a-zA-Z0-9]$
 ignored-argument-names=_.*
 init-import=no
 redefining-builtins-modules=past.builtins,future.builtins,builtins,io
-
-[tool:pytest]
-addopts=--durations 10 --cov=binstar_client --cov-report term-missing
-cache_dir=.cache/pytest
-# Treat all warnings errors: https://til.simonwillison.net/pytest/treat-warnings-as-errors
-filterwarnings =
-    error

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,28 +1,3 @@
-[mypy]
-cache_dir = .cache/mypy
-check_untyped_defs = False
-disallow_any_decorated = False
-disallow_any_explicit = False
-disallow_any_expr = False
-disallow_any_generics = False
-disallow_any_unimported = False
-disallow_incomplete_defs = True
-disallow_subclassing_any = False
-disallow_untyped_calls = False
-disallow_untyped_decorators = False
-disallow_untyped_defs = False
-ignore_errors = False
-ignore_missing_imports = True
-namespace_packages = True
-no_implicit_optional = True
-python_version = 3.8
-strict_optional = True
-warn_no_return = True
-warn_redundant_casts = True
-warn_return_any = False
-warn_unreachable = True
-warn_unused_ignores = True
-
 [pycodestyle]
 count = False
 format = default


### PR DESCRIPTION
## Summary

Moves the settings for `mypy` and `pytest` from `setup.cfg` into `pyproject.toml`. Also, simplifies the `mypy` settings to the minimal number of overrides to match current behavior.