### PR TITLE
chore: Replace Python 3.8 with 3.13 in the test matrix

### DIFF
--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
       # most of these steps might be anchored to corresponding ones in the "lint_code" job


### PR DESCRIPTION
Resolves #758.