### PR TITLE
HUB-3505_basic_repocore_pkg_management

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -760,12 +760,8 @@ def view_command(
         "-c",
         help="Channel in format 'namespace/channel' or 'channel'.",
     ),
-    namespace: Optional[str] = typer.Option(
-        None, "--namespace", "-n", help="Namespace the channel belongs to"
-    ),
-    packages: bool = typer.Option(
-        False, "--packages", "-p", help="List the packages in the channel."
-    ),
+    namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Namespace the channel belongs to"),
+    packages: bool = typer.Option(False, "--packages", "-p", help="List the packages in the channel."),
     files: bool = typer.Option(
         False, "--files", help="List individual files (with the exact filename to remove) instead of a package summary."
     ),
@@ -851,9 +847,7 @@ def remove_package_command(
         "-c",
         help="Channel in format 'namespace/channel' or 'channel'.",
     ),
-    namespace: Optional[str] = typer.Option(
-        None, "--namespace", "-n", help="Namespace the channel belongs to"
-    ),
+    namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Namespace the channel belongs to"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip the confirmation prompt."),
 ) -> None:
     """Remove a single package file (by filename) from a channel.

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -479,6 +479,24 @@ def modify_command(
         console.print(f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[indexing_behavior]}.")
 
 
+def _make_owner_probe(token_value: Optional[str], org_site_value: Optional[str]):
+    """Build the anaconda.org owner probe used to route bare names to dotorg.
+
+    Note: ``--at`` selects the anaconda.com (repo) domain and is NOT a valid
+    anaconda.org site alias, so only ``--site`` (org_site_value) is forwarded.
+    """
+
+    def _owner_probe(name: str) -> bool:
+        try:
+            aserver_api = get_server_api(token_value, org_site_value)
+            aserver_api.user(name)
+            return True
+        except Exception:
+            return False
+
+    return _owner_probe
+
+
 def _do_upload(
     api,
     files: List[str],
@@ -507,15 +525,7 @@ def _do_upload(
         raise typer.Exit(1)
 
     # Probe used to detect anaconda.org owners so a bare name can route to dotorg.
-    # Note: ``--at`` selects the anaconda.com (repo) domain and is NOT a valid
-    # anaconda.org site alias, so it must not be forwarded here.
-    def _owner_probe(name: str) -> bool:
-        try:
-            aserver_api = get_server_api(token_value, org_site_value)
-            aserver_api.user(name)
-            return True
-        except Exception:
-            return False
+    _owner_probe = _make_owner_probe(token_value, org_site_value)
 
     resolved = _resolve_channels_with_namespaces(
         api, channels, namespace, from_deprecated_channel_flag, owner_probe=_owner_probe
@@ -702,18 +712,6 @@ def share_command(
         console.print(f"[green]Success![/green] {action.capitalize()}d channel '[cyan]{ch}[/cyan]' with {user}")
 
 
-def _resolve_channel_arg(api, channel: str, namespace: Optional[str]) -> str:
-    """Resolve a ``-c`` channel arg to the ``namespace/channel`` form (or a subchannel path).
-
-    A ``namespace/channel`` or ``--namespace``-qualified name is used as-is. A bare
-    channel name is resolved to its namespace the same way the other subcommands do.
-    """
-    resolved = _resolve_namespace_and_channel(api, channel, namespace)
-    if resolved.namespace:
-        return f"{resolved.namespace}/{resolved.channel_name}"
-    return resolved.channel_name
-
-
 def _iter_all_artifacts(api, channel: str):
     """Yield every package (artifact) in ``channel``, paging through the listing."""
     offset = 0
@@ -788,7 +786,10 @@ def view_command(
         packages = True
 
     api = ctx.obj.repo_api
-    resolved = _resolve_channel_arg(api, channels[0], namespace)
+    # view lists packages/files/ckeys, which are anaconda.com (repocore) concepts;
+    # for anaconda.org owners use `anaconda show`. Resolve the same way show/modify do.
+    resolved_channel = _resolve_namespace_and_channel(api, channels[0], namespace)
+    resolved = f"{resolved_channel.namespace}/{resolved_channel.channel_name}"
 
     if files:
         table = Table(title=f"Files in {resolved}")
@@ -841,26 +842,91 @@ def _fmt_size(num_bytes: int) -> str:
     return f"{size:.1f} GB"
 
 
+def _remove_from_repo(api, channel: str, target: str, force: bool) -> None:
+    """Remove a single file (by filename) from an anaconda.com repo channel.
+
+    ``target`` is the bare filename; it is resolved to its file (ckey) by
+    scanning the channel, then removed via the bulk endpoint so only that one
+    file goes, not the whole package.
+    """
+    matches = _find_file_by_name(api, channel, target)
+    if not matches:
+        console.print(
+            f"[red]Error:[/red] No file named '[cyan]{target}[/cyan]' found in channel '[cyan]{channel}[/cyan]'. "
+            f"Run 'anaconda channel view -c {channel} --files' to list removable filenames."
+        )
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        console.print(f"[red]Error:[/red] '{target}' matches more than one file in '{channel}':")
+        for family, name, ckey in matches:
+            console.print(f"  - {family}/{name}: [cyan]{ckey}[/cyan]")
+        console.print("This is unexpected for a single filename; contact support if it persists.")
+        raise typer.Exit(1)
+
+    family, name, ckey = matches[0]
+
+    if not force:
+        console.print(f"About to remove [cyan]{ckey}[/cyan] ({family}/{name}) from [cyan]{channel}[/cyan].")
+        if not typer.confirm("Are you sure?"):
+            raise typer.Exit(0)
+
+    api.delete_artifact_file(channel, family, name, ckey)
+    console.print(f"[green]Success![/green] Removed [cyan]{target}[/cyan] from '[cyan]{channel}[/cyan]'.")
+
+
+def _remove_from_dotorg(owner: str, target: str, token_value, org_site_value, force: bool) -> None:
+    """Delegate a package removal to the anaconda.org ``remove`` path.
+
+    anaconda.org has no bare-filename delete; its grammar is
+    ``owner/package/version/filename``. The ``target`` is the part after the
+    owner (``-c owner`` supplies the owner), so we reconstruct the full spec and
+    hand it to the legacy remove command — the same proxying ``channel upload``
+    does for owner-only names.
+    """
+    from binstar_client.commands import remove as remove_mod
+    from binstar_client.utils import parse_specs
+
+    spec = target if target.startswith(f"{owner}/") else f"{owner}/{target}"
+    args = argparse.Namespace(
+        token=token_value,
+        site=org_site_value,
+        specs=[parse_specs(spec)],
+        force=force,
+    )
+    remove_mod.main(args)
+
+
 @app.command(name="remove-package", help="Remove a package file from a channel")
 def remove_package_command(
     ctx: typer.Context,
-    filename: str = typer.Argument(..., help="The package filename to remove (e.g. numpy-2.2.5-py313h51bfb38_3.conda)"),
+    target: str = typer.Argument(
+        ...,
+        metavar="PACKAGE",
+        help=(
+            "For an anaconda.com channel: the package filename to remove "
+            "(e.g. numpy-2.2.5-py313h51bfb38_3.conda). For an anaconda.org owner: "
+            "the package spec 'package/version/filename'."
+        ),
+    ),
     channel: Optional[List[str]] = typer.Option(
         None,
         "--channel",
         "-c",
-        help="Channel in format 'namespace/channel' or 'channel'.",
+        help="Channel 'namespace/channel'/'channel', or an anaconda.org owner.",
     ),
     namespace: Optional[str] = typer.Option(
         None, "--namespace", "-n", help="Namespace the channel belongs to"
     ),
     force: bool = typer.Option(False, "--force", "-f", help="Skip the confirmation prompt."),
 ) -> None:
-    """Remove a single package file (by filename) from a channel.
+    """Remove a single package file from a channel.
 
-    A package spans many files, so removal targets one file. The filename is
-    resolved to its file (ckey) by scanning the channel; run
-    ``anaconda channel view -c CHANNEL --files`` to see removable filenames.
+    Like ``channel upload``, this proxies across systems: a ``-c`` value that names
+    an anaconda.org owner routes to anaconda.org; otherwise it targets an
+    anaconda.com (repocore) channel. On anaconda.com a package spans many files, so
+    removal targets one file — the filename is resolved to its file (ckey) by
+    scanning the channel; run ``anaconda channel view -c CHANNEL --files`` to see
+    removable filenames.
     """
     channels = channel or []
     if not channels:
@@ -871,31 +937,26 @@ def remove_package_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    resolved = _resolve_channel_arg(api, channels[0], namespace)
+    params = getattr(ctx.obj, "params", {})
+    token_value = params.get("token")
+    # --at selects the anaconda.com domain; only --site is an anaconda.org alias.
+    org_site_value = params.get("site")
 
-    matches = _find_file_by_name(api, resolved, filename)
-    if not matches:
-        console.print(
-            f"[red]Error:[/red] No file named '[cyan]{filename}[/cyan]' found in channel '[cyan]{resolved}[/cyan]'. "
-            f"Run 'anaconda channel view -c {resolved} --files' to list removable filenames."
-        )
-        raise typer.Exit(1)
-    if len(matches) > 1:
-        console.print(f"[red]Error:[/red] '{filename}' matches more than one file in '{resolved}':")
-        for family, name, ckey in matches:
-            console.print(f"  - {family}/{name}: [cyan]{ckey}[/cyan]")
-        console.print("This is unexpected for a single filename; contact support if it persists.")
-        raise typer.Exit(1)
+    # Classify the -c target the same way `channel upload` does: a bare name that
+    # matches an anaconda.org owner routes to dotorg, otherwise anaconda.com.
+    owner_probe = _make_owner_probe(token_value, org_site_value)
+    from binstar_client.repocore.resolve import classify_and_resolve
 
-    family, name, ckey = matches[0]
+    resolved = classify_and_resolve(api, channels[0], namespace, owner_probe=owner_probe)
 
-    if not force:
-        console.print(f"About to remove [cyan]{ckey}[/cyan] ({family}/{name}) from [cyan]{resolved}[/cyan].")
-        if not typer.confirm("Are you sure?"):
-            raise typer.Exit(0)
+    if resolved.target == "org":
+        _remove_from_dotorg(cast(str, resolved.owner), target, token_value, org_site_value, force)
+        return
 
-    api.delete_artifact_file(resolved, family, name, ckey)
-    console.print(f"[green]Success![/green] Removed [cyan]{filename}[/cyan] from '[cyan]{resolved}[/cyan]'.")
+    channel_path = (
+        f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
+    )
+    _remove_from_repo(api, channel_path, target, force)
 
 
 channel_notices.mount_notice_subcommand(app)

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -702,4 +702,200 @@ def share_command(
         console.print(f"[green]Success![/green] {action.capitalize()}d channel '[cyan]{ch}[/cyan]' with {user}")
 
 
+def _resolve_channel_arg(api, channel: str, namespace: Optional[str]) -> str:
+    """Resolve a ``-c`` channel arg to the ``namespace/channel`` form (or a subchannel path).
+
+    A ``namespace/channel`` or ``--namespace``-qualified name is used as-is. A bare
+    channel name is resolved to its namespace the same way the other subcommands do.
+    """
+    resolved = _resolve_namespace_and_channel(api, channel, namespace)
+    if resolved.namespace:
+        return f"{resolved.namespace}/{resolved.channel_name}"
+    return resolved.channel_name
+
+
+def _iter_all_artifacts(api, channel: str):
+    """Yield every package (artifact) in ``channel``, paging through the listing."""
+    offset = 0
+    while True:
+        artifacts, total = api.list_artifacts(channel, offset=offset, limit=_PAGE_SIZE)
+        yield from artifacts
+        offset += len(artifacts)
+        if not artifacts or offset >= total:
+            break
+
+
+def _iter_artifact_files(api, channel: str, family: str, name: str):
+    """Yield every file of one package in ``channel``, paging through the listing."""
+    offset = 0
+    while True:
+        files, total = api.list_artifact_files(channel, family, name, offset=offset, limit=_PAGE_SIZE)
+        yield from files
+        offset += len(files)
+        if not files or offset >= total:
+            break
+
+
+def _find_file_by_name(api, channel: str, filename: str):
+    """Find the (family, name, ckey) of a package file by its bare filename.
+
+    Scans the channel's packages and their files, matching on the ckey basename.
+    Returns a list of matching ``(family, name, ckey)`` tuples so the caller can
+    report ambiguity (the same filename under more than one package/subdir).
+    """
+    matches: List[Tuple[str, str, str]] = []
+    for artifact in _iter_all_artifacts(api, channel):
+        for f in _iter_artifact_files(api, channel, artifact.family, artifact.name):
+            if f.filename == filename:
+                matches.append((artifact.family, artifact.name, f.ckey))
+    return matches
+
+
+@app.command(name="view", help="View packages in a channel")
+def view_command(
+    ctx: typer.Context,
+    channel: Optional[List[str]] = typer.Option(
+        None,
+        "--channel",
+        "-c",
+        help="Channel in format 'namespace/channel' or 'channel'.",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None, "--namespace", "-n", help="Namespace the channel belongs to"
+    ),
+    packages: bool = typer.Option(
+        False, "--packages", "-p", help="List the packages in the channel."
+    ),
+    files: bool = typer.Option(
+        False, "--files", help="List individual files (with the exact filename to remove) instead of a package summary."
+    ),
+) -> None:
+    """View the packages in a channel.
+
+    The package summary shows one row per package. ``--files`` drills into every
+    file so you can see the exact filename to pass to ``remove-package``.
+    """
+    channels = channel or []
+    if not channels:
+        console.print("[red]Error:[/red] No channel specified. Use --channel/-c to specify a channel.")
+        raise typer.Exit(1)
+    if len(channels) > 1:
+        console.print("[red]Error:[/red] view accepts a single channel; specify -c once.")
+        raise typer.Exit(1)
+
+    # --packages/-p and --files select what to view; default to the package summary.
+    if not packages and not files:
+        packages = True
+
+    api = ctx.obj.repo_api
+    resolved = _resolve_channel_arg(api, channels[0], namespace)
+
+    if files:
+        table = Table(title=f"Files in {resolved}")
+        table.add_column("Filename", style="cyan")
+        table.add_column("Package")
+        table.add_column("Family")
+        table.add_column("Size", justify="right")
+        row_count = 0
+        for artifact in _iter_all_artifacts(api, resolved):
+            for f in _iter_artifact_files(api, resolved, artifact.family, artifact.name):
+                table.add_row(f.filename, f.name or artifact.name, f.family or artifact.family, _fmt_size(f.size))
+                row_count += 1
+    else:
+        table = Table(title=f"Packages in {resolved}")
+        table.add_column("Package", style="cyan")
+        table.add_column("Family")
+        table.add_column("Versions", justify="right")
+        table.add_column("Files", justify="right")
+        table.add_column("Downloads", justify="right")
+        row_count = 0
+        for artifact in _iter_all_artifacts(api, resolved):
+            table.add_row(
+                artifact.name,
+                artifact.family,
+                str(len(artifact.available_versions)),
+                str(artifact.file_count),
+                str(artifact.download_count),
+            )
+            row_count += 1
+
+    if row_count == 0:
+        console.print(f"No packages found in [cyan]{resolved}[/cyan].")
+        return
+
+    if console.height and table.row_count > console.height:
+        with console.pager():
+            console.print(f"[dim]Showing {table.row_count} rows — ↑/↓ to scroll, press q to quit.[/dim]")
+            console.print(table)
+    else:
+        console.print(table)
+
+
+def _fmt_size(num_bytes: int) -> str:
+    """Human-readable byte size for the files table."""
+    size = float(num_bytes or 0)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
+
+
+@app.command(name="remove-package", help="Remove a package file from a channel")
+def remove_package_command(
+    ctx: typer.Context,
+    filename: str = typer.Argument(..., help="The package filename to remove (e.g. numpy-2.2.5-py313h51bfb38_3.conda)"),
+    channel: Optional[List[str]] = typer.Option(
+        None,
+        "--channel",
+        "-c",
+        help="Channel in format 'namespace/channel' or 'channel'.",
+    ),
+    namespace: Optional[str] = typer.Option(
+        None, "--namespace", "-n", help="Namespace the channel belongs to"
+    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip the confirmation prompt."),
+) -> None:
+    """Remove a single package file (by filename) from a channel.
+
+    A package spans many files, so removal targets one file. The filename is
+    resolved to its file (ckey) by scanning the channel; run
+    ``anaconda channel view -c CHANNEL --files`` to see removable filenames.
+    """
+    channels = channel or []
+    if not channels:
+        console.print("[red]Error:[/red] No channel specified. Use --channel/-c to specify a channel.")
+        raise typer.Exit(1)
+    if len(channels) > 1:
+        console.print("[red]Error:[/red] remove-package accepts a single channel; specify -c once.")
+        raise typer.Exit(1)
+
+    api = ctx.obj.repo_api
+    resolved = _resolve_channel_arg(api, channels[0], namespace)
+
+    matches = _find_file_by_name(api, resolved, filename)
+    if not matches:
+        console.print(
+            f"[red]Error:[/red] No file named '[cyan]{filename}[/cyan]' found in channel '[cyan]{resolved}[/cyan]'. "
+            f"Run 'anaconda channel view -c {resolved} --files' to list removable filenames."
+        )
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        console.print(f"[red]Error:[/red] '{filename}' matches more than one file in '{resolved}':")
+        for family, name, ckey in matches:
+            console.print(f"  - {family}/{name}: [cyan]{ckey}[/cyan]")
+        console.print("This is unexpected for a single filename; contact support if it persists.")
+        raise typer.Exit(1)
+
+    family, name, ckey = matches[0]
+
+    if not force:
+        console.print(f"About to remove [cyan]{ckey}[/cyan] ({family}/{name}) from [cyan]{resolved}[/cyan].")
+        if not typer.confirm("Are you sure?"):
+            raise typer.Exit(0)
+
+    api.delete_artifact_file(resolved, family, name, ckey)
+    console.print(f"[green]Success![/green] Removed [cyan]{filename}[/cyan] from '[cyan]{resolved}[/cyan]'.")
+
+
 channel_notices.mount_notice_subcommand(app)

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -12,6 +12,7 @@ from glob import glob
 from typing import List, Optional, Tuple, cast
 
 import typer
+from pydantic import BaseModel
 from rich.panel import Panel
 
 from anaconda_cli_base.console import Table, console, select_from_list
@@ -416,20 +417,16 @@ def show_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    params = getattr(ctx.obj, "params", {})
-    token_value = params.get("token")
-    # --at selects the anaconda.com domain; only --site is an anaconda.org alias.
-    org_site_value = params.get("site")
+    creds = _DotOrgCredentials.from_ctx(ctx)
 
     # Classify the name the same way `channel upload`/`remove-package` do: a bare
     # name matching an anaconda.org owner routes to dotorg, otherwise anaconda.com.
-    owner_probe = _make_owner_probe(token_value, org_site_value)
-    resolved = classify_and_resolve(api, name, namespace, owner_probe=owner_probe)
+    resolved = classify_and_resolve(api, name, namespace, owner_probe=creds.owner_probe)
 
     if resolved.target == "org":
         # anaconda.org packages/files listings don't apply; `anaconda show OWNER`
         # already lists the owner's packages.
-        _show_dotorg(cast(str, resolved.owner), token_value, org_site_value)
+        _show_dotorg(cast(str, resolved.owner), creds.token, creds.site)
         return
 
     name = f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
@@ -523,22 +520,35 @@ def modify_command(
         console.print(f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[indexing_behavior]}.")
 
 
-def _make_owner_probe(token_value: Optional[str], org_site_value: Optional[str]):
-    """Build the anaconda.org owner probe used to route bare names to dotorg.
+class _DotOrgCredentials(BaseModel):
+    """The ``--token``/``--site`` pair plus the anaconda.org owner probe.
+
+    These always travel together: the probe routes a bare name to dotorg when it
+    matches an anaconda.org owner, and the same token/site then drive the dotorg
+    operation (show/remove/upload) after resolution. Bundling them keeps the
+    per-command wiring to one line and the ``--at`` vs ``--site`` rule in one place.
 
     Note: ``--at`` selects the anaconda.com (repo) domain and is NOT a valid
-    anaconda.org site alias, so only ``--site`` (org_site_value) is forwarded.
+    anaconda.org site alias, so only ``--site`` is carried here as ``site``.
     """
 
-    def _owner_probe(name: str) -> bool:
+    token: Optional[str] = None
+    site: Optional[str] = None
+
+    @classmethod
+    def from_ctx(cls, ctx) -> "_DotOrgCredentials":
+        """Read ``--token``/``--site`` off the command context's params."""
+        params = getattr(ctx.obj, "params", {})
+        return cls(token=params.get("token"), site=params.get("site"))
+
+    def owner_probe(self, name: str) -> bool:
+        """Whether ``name`` is a real anaconda.org owner (user or organization)."""
         try:
-            aserver_api = get_server_api(token_value, org_site_value)
+            aserver_api = get_server_api(self.token, self.site)
             aserver_api.user(name)
             return True
         except Exception:
             return False
-
-    return _owner_probe
 
 
 def _do_upload(
@@ -548,8 +558,7 @@ def _do_upload(
     namespace: Optional[str],
     package_type: Optional[str],
     from_deprecated_channel_flag: bool,
-    token_value: Optional[str],
-    org_site_value: Optional[str] = None,
+    creds: "_DotOrgCredentials",
     labels: Optional[List[str]] = None,
     org_upload_args: object = None,
 ) -> None:
@@ -568,11 +577,8 @@ def _do_upload(
         console.print("[red]Error:[/red] No channel specified. Use --channel option to specify target channel(s).")
         raise typer.Exit(1)
 
-    # Probe used to detect anaconda.org owners so a bare name can route to dotorg.
-    _owner_probe = _make_owner_probe(token_value, org_site_value)
-
     resolved = _resolve_channels_with_namespaces(
-        api, channels, namespace, from_deprecated_channel_flag, owner_probe=_owner_probe
+        api, channels, namespace, from_deprecated_channel_flag, owner_probe=creds.owner_probe
     )
 
     org_targets = [r for r in resolved if r.target == "org"]
@@ -613,16 +619,14 @@ def upload_command(
     org_upload_args: object = None,
 ) -> None:
     """Programmatic entry for uploads (used by the ``anaconda upload`` bridge)."""
-    token_value = None
-    org_site_value = None
     if ctx is None:
         from anaconda_cli_base.cli import ContextExtras
         from binstar_client import __version__
 
         # Carry --site/--token from the `anaconda upload` bridge, if provided.
-        token_value = getattr(org_upload_args, "token", None)
+        # `anaconda upload --site` is an anaconda.org alias (see _DotOrgCredentials).
         site_value = getattr(org_upload_args, "site", None)
-        org_site_value = site_value  # `anaconda upload --site` is an anaconda.org alias
+        creds = _DotOrgCredentials(token=getattr(org_upload_args, "token", None), site=site_value)
 
         ctx_obj = ContextExtras()
         ctx_obj.repo_api = RepoCoreClient(site=site_value, version=__version__)
@@ -632,10 +636,7 @@ def upload_command(
 
         ctx = FakeContext()
     else:
-        params = getattr(ctx.obj, "params", {})
-        token_value = params.get("token")
-        # --at selects the anaconda.com domain; only --site is an anaconda.org alias.
-        org_site_value = params.get("site")
+        creds = _DotOrgCredentials.from_ctx(ctx)
 
     _do_upload(
         ctx.obj.repo_api,
@@ -644,8 +645,7 @@ def upload_command(
         namespace,
         package_type,
         from_deprecated_channel_flag,
-        token_value,
-        org_site_value=org_site_value,
+        creds,
         labels=labels,
         org_upload_args=org_upload_args,
     )
@@ -684,8 +684,6 @@ def _upload_cli(
     ),
 ) -> None:
     """Upload packages to your Anaconda repository."""
-    params = getattr(ctx.obj, "params", {})
-    token_value = params.get("token")
     # typer validates -t against the repocore enum at the CLI boundary; hand the
     # raw string down so _do_upload can validate per-target uniformly.
     _do_upload(
@@ -695,8 +693,7 @@ def _upload_cli(
         namespace,
         package_type.value if package_type else None,
         from_deprecated_channel_flag=False,
-        token_value=token_value,
-        org_site_value=params.get("site"),
+        creds=_DotOrgCredentials.from_ctx(ctx),
         labels=label or [],
     )
 
@@ -982,18 +979,14 @@ def remove_package_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    params = getattr(ctx.obj, "params", {})
-    token_value = params.get("token")
-    # --at selects the anaconda.com domain; only --site is an anaconda.org alias.
-    org_site_value = params.get("site")
+    creds = _DotOrgCredentials.from_ctx(ctx)
 
     # Classify the -c target the same way `channel upload` does: a bare name that
     # matches an anaconda.org owner routes to dotorg, otherwise anaconda.com.
-    owner_probe = _make_owner_probe(token_value, org_site_value)
-    resolved = classify_and_resolve(api, channels[0], namespace, owner_probe=owner_probe)
+    resolved = classify_and_resolve(api, channels[0], namespace, owner_probe=creds.owner_probe)
 
     if resolved.target == "org":
-        _remove_from_dotorg(cast(str, resolved.owner), target, token_value, org_site_value, force)
+        _remove_from_dotorg(cast(str, resolved.owner), target, creds.token, creds.site, force)
         return
 
     channel_path = f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -885,6 +885,27 @@ def _remove_from_repo(api, channel: str, target: str, force: bool) -> None:
     console.print(f"[green]Success![/green] Removed [cyan]{target}[/cyan] from '[cyan]{channel}[/cyan]'.")
 
 
+def _ensure_binstar_console_logging() -> None:
+    """Make the legacy ``binstar`` logger print to the console at INFO.
+
+    The delegated legacy commands (``show``/``remove``) write their user-facing
+    output via ``logging`` at INFO. Under the standalone ``binstar`` entrypoint
+    that logger is configured by ``setup_logging``; but when we call their
+    ``main()`` from inside the ``anaconda channel`` Typer app nothing has
+    configured it, so INFO records are dropped (the logger defaults to WARNING
+    with no handler) and the command appears to print nothing. Install a plain
+    console handler at INFO once, only if none is already attached.
+    """
+    binstar_logger = logging.getLogger("binstar")
+    if binstar_logger.level == logging.NOTSET or binstar_logger.level > logging.INFO:
+        binstar_logger.setLevel(logging.INFO)
+    if not any(isinstance(h, logging.StreamHandler) for h in binstar_logger.handlers):
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        binstar_logger.addHandler(handler)
+
+
 def _show_dotorg(owner: str, token_value, org_site_value) -> None:
     """Delegate a channel show for an anaconda.org owner to the legacy ``show`` path.
 
@@ -892,6 +913,9 @@ def _show_dotorg(owner: str, token_value, org_site_value) -> None:
     the owner's packages, which is the closest equivalent — the same proxying
     ``channel upload`` does for owner-only names.
     """
+    # show.main emits its listing through the binstar logger at INFO; ensure it
+    # reaches the console when invoked via this Typer app (see helper).
+    _ensure_binstar_console_logging()
     args = argparse.Namespace(
         token=token_value,
         site=org_site_value,

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -947,9 +947,7 @@ def remove_package_command(
         _remove_from_dotorg(cast(str, resolved.owner), target, token_value, org_site_value, force)
         return
 
-    channel_path = (
-        f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
-    )
+    channel_path = f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
     _remove_from_repo(api, channel_path, target, force)
 
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -17,16 +17,18 @@ from rich.panel import Panel
 from anaconda_cli_base.console import Table, console, select_from_list
 from binstar_client import __version__
 from binstar_client.commands import _channel_notices as channel_notices
+from binstar_client.commands import remove as remove_mod
 from binstar_client.commands import upload as upload_mod
 from binstar_client.repocore import RepoCoreClient
 from binstar_client.repocore.errors import RepoCoreError, Unauthorized
 from binstar_client.repocore.package_utils import PackageType, determine_package_type, windows_glob
 from binstar_client.repocore.resolve import (
+    classify_and_resolve,
     resolve_channels_with_namespaces as _resolve_channels_with_namespaces,
     resolve_namespace_and_channel as _resolve_namespace_and_channel,
     resolve_no_namespace as _resolve_no_namespace,
 )
-from binstar_client.utils import get_server_api
+from binstar_client.utils import get_server_api, parse_specs
 from binstar_client.utils.console_utils import configure_console_encoding
 
 __all__ = ["app", "_resolve_namespace_and_channel", "_resolve_no_namespace", "_resolve_channels_with_namespaces"]
@@ -719,7 +721,8 @@ def _iter_all_artifacts(api, channel: str):
         artifacts, total = api.list_artifacts(channel, offset=offset, limit=_PAGE_SIZE)
         yield from artifacts
         offset += len(artifacts)
-        if not artifacts or offset >= total:
+        # Stop on an empty/short page too, so an over-reported total can't loop forever.
+        if not artifacts or len(artifacts) < _PAGE_SIZE or offset >= total:
             break
 
 
@@ -730,7 +733,8 @@ def _iter_artifact_files(api, channel: str, family: str, name: str):
         files, total = api.list_artifact_files(channel, family, name, offset=offset, limit=_PAGE_SIZE)
         yield from files
         offset += len(files)
-        if not files or offset >= total:
+        # Stop on an empty/short page too, so an over-reported total can't loop forever.
+        if not files or len(files) < _PAGE_SIZE or offset >= total:
             break
 
 
@@ -747,6 +751,16 @@ def _find_file_by_name(api, channel: str, filename: str):
             if f.filename == filename:
                 matches.append((artifact.family, artifact.name, f.ckey))
     return matches
+
+
+def _fmt_size(num_bytes: int) -> str:
+    """Human-readable byte size for the files table."""
+    size = float(num_bytes or 0)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
 
 
 @app.command(name="view", help="View packages in a channel")
@@ -828,16 +842,6 @@ def view_command(
         console.print(table)
 
 
-def _fmt_size(num_bytes: int) -> str:
-    """Human-readable byte size for the files table."""
-    size = float(num_bytes or 0)
-    for unit in ("B", "KB", "MB", "GB"):
-        if size < 1024 or unit == "GB":
-            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
-        size /= 1024
-    return f"{size:.1f} GB"
-
-
 def _remove_from_repo(api, channel: str, target: str, force: bool) -> None:
     """Remove a single file (by filename) from an anaconda.com repo channel.
 
@@ -879,9 +883,6 @@ def _remove_from_dotorg(owner: str, target: str, token_value, org_site_value, fo
     hand it to the legacy remove command — the same proxying ``channel upload``
     does for owner-only names.
     """
-    from binstar_client.commands import remove as remove_mod
-    from binstar_client.utils import parse_specs
-
     spec = target if target.startswith(f"{owner}/") else f"{owner}/{target}"
     args = argparse.Namespace(
         token=token_value,
@@ -939,17 +940,13 @@ def remove_package_command(
     # Classify the -c target the same way `channel upload` does: a bare name that
     # matches an anaconda.org owner routes to dotorg, otherwise anaconda.com.
     owner_probe = _make_owner_probe(token_value, org_site_value)
-    from binstar_client.repocore.resolve import classify_and_resolve
-
     resolved = classify_and_resolve(api, channels[0], namespace, owner_probe=owner_probe)
 
     if resolved.target == "org":
         _remove_from_dotorg(cast(str, resolved.owner), target, token_value, org_site_value, force)
         return
 
-    channel_path = (
-        f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
-    )
+    channel_path = f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
     _remove_from_repo(api, channel_path, target, force)
 
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -18,6 +18,7 @@ from anaconda_cli_base.console import Table, console, select_from_list
 from binstar_client import __version__
 from binstar_client.commands import _channel_notices as channel_notices
 from binstar_client.commands import remove as remove_mod
+from binstar_client.commands import show as show_mod
 from binstar_client.commands import upload as upload_mod
 from binstar_client.repocore import RepoCoreClient
 from binstar_client.repocore.errors import RepoCoreError, Unauthorized
@@ -390,11 +391,48 @@ def show_command(
     name: str = typer.Argument(..., help="Channel name to show"),
     namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Namespace the channel belongs to"),
     full_details: bool = typer.Option(False, "--full-details", help="Show full details including subchannels"),
+    packages: bool = typer.Option(False, "--packages", "-p", help="Also list the packages in the channel."),
+    files: bool = typer.Option(
+        False,
+        "--files",
+        help="Also list individual files (with the exact filename to remove) instead of a package summary.",
+    ),
 ) -> None:
-    """Show information about a channel."""
+    """Show information about a channel.
+
+    Like ``channel upload``, this proxies across systems: a bare ``name`` that
+    matches an anaconda.org owner routes to anaconda.org (delegating to the
+    legacy ``anaconda show``); otherwise it targets an anaconda.com (repocore)
+    channel.
+
+    By default this prints channel metadata only. ``--packages/-p`` appends a
+    package summary; ``--files`` appends a per-file listing (with the exact
+    filename to pass to ``remove-package``). The two listing flags are alternatives.
+    """
+    # --packages/-p and --files pick the listing format; reject both at once
+    # rather than silently letting one win.
+    if packages and files:
+        console.print("[red]Error:[/red] --packages/-p and --files are mutually exclusive; specify at most one.")
+        raise typer.Exit(1)
+
     api = ctx.obj.repo_api
-    resolved = _resolve_namespace_and_channel(api, name, namespace)
-    name = f"{resolved.namespace}/{resolved.channel_name}"
+    params = getattr(ctx.obj, "params", {})
+    token_value = params.get("token")
+    # --at selects the anaconda.com domain; only --site is an anaconda.org alias.
+    org_site_value = params.get("site")
+
+    # Classify the name the same way `channel upload`/`remove-package` do: a bare
+    # name matching an anaconda.org owner routes to dotorg, otherwise anaconda.com.
+    owner_probe = _make_owner_probe(token_value, org_site_value)
+    resolved = classify_and_resolve(api, name, namespace, owner_probe=owner_probe)
+
+    if resolved.target == "org":
+        # anaconda.org packages/files listings don't apply; `anaconda show OWNER`
+        # already lists the owner's packages.
+        _show_dotorg(cast(str, resolved.owner), token_value, org_site_value)
+        return
+
+    name = f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
     channel_data = api.get_namespace_channel(name)
 
     subchannels_response = None
@@ -438,6 +476,10 @@ def show_command(
                 str(sub.artifact_count),
             )
         console.print(sub_table)
+
+    if packages or files:
+        console.print()
+        _render_package_listing(api, name, files)
 
 
 @app.command(name="modify", help="Modify channel settings")
@@ -763,64 +805,33 @@ def _fmt_size(num_bytes: int) -> str:
     return f"{size:.1f} GB"
 
 
-@app.command(name="view", help="View packages in a channel")
-def view_command(
-    ctx: typer.Context,
-    channel: Optional[List[str]] = typer.Option(
-        None,
-        "--channel",
-        "-c",
-        help="Channel in format 'namespace/channel' or 'channel'.",
-    ),
-    namespace: Optional[str] = typer.Option(None, "--namespace", "-n", help="Namespace the channel belongs to"),
-    packages: bool = typer.Option(False, "--packages", "-p", help="List the packages in the channel."),
-    files: bool = typer.Option(
-        False, "--files", help="List individual files (with the exact filename to remove) instead of a package summary."
-    ),
-) -> None:
-    """View the packages in a channel.
+def _render_package_listing(api, channel: str, files: bool) -> None:
+    """Print the package (or, with ``files``, per-file) listing for a channel.
 
-    The package summary shows one row per package. ``--files`` drills into every
-    file so you can see the exact filename to pass to ``remove-package``.
+    The package summary shows one row per package. ``files=True`` drills into
+    every file so the exact filename to pass to ``remove-package`` is visible.
+    Long listings page through the console.
     """
-    channels = channel or []
-    if not channels:
-        console.print("[red]Error:[/red] No channel specified. Use --channel/-c to specify a channel.")
-        raise typer.Exit(1)
-    if len(channels) > 1:
-        console.print("[red]Error:[/red] view accepts a single channel; specify -c once.")
-        raise typer.Exit(1)
-
-    # --packages/-p and --files select what to view; default to the package summary.
-    if not packages and not files:
-        packages = True
-
-    api = ctx.obj.repo_api
-    # view lists packages/files/ckeys, which are anaconda.com (repocore) concepts;
-    # for anaconda.org owners use `anaconda show`. Resolve the same way show/modify do.
-    resolved_channel = _resolve_namespace_and_channel(api, channels[0], namespace)
-    resolved = f"{resolved_channel.namespace}/{resolved_channel.channel_name}"
-
     if files:
-        table = Table(title=f"Files in {resolved}")
+        table = Table(title=f"Files in {channel}")
         table.add_column("Filename", style="cyan")
         table.add_column("Package")
         table.add_column("Family")
         table.add_column("Size", justify="right")
         row_count = 0
-        for artifact in _iter_all_artifacts(api, resolved):
-            for f in _iter_artifact_files(api, resolved, artifact.family, artifact.name):
+        for artifact in _iter_all_artifacts(api, channel):
+            for f in _iter_artifact_files(api, channel, artifact.family, artifact.name):
                 table.add_row(f.filename, f.name or artifact.name, f.family or artifact.family, _fmt_size(f.size))
                 row_count += 1
     else:
-        table = Table(title=f"Packages in {resolved}")
+        table = Table(title=f"Packages in {channel}")
         table.add_column("Package", style="cyan")
         table.add_column("Family")
         table.add_column("Versions", justify="right")
         table.add_column("Files", justify="right")
         table.add_column("Downloads", justify="right")
         row_count = 0
-        for artifact in _iter_all_artifacts(api, resolved):
+        for artifact in _iter_all_artifacts(api, channel):
             table.add_row(
                 artifact.name,
                 artifact.family,
@@ -831,7 +842,7 @@ def view_command(
             row_count += 1
 
     if row_count == 0:
-        console.print(f"No packages found in [cyan]{resolved}[/cyan].")
+        console.print(f"No packages found in [cyan]{channel}[/cyan].")
         return
 
     if console.height and table.row_count > console.height:
@@ -872,6 +883,21 @@ def _remove_from_repo(api, channel: str, target: str, force: bool) -> None:
 
     api.delete_artifact_file(channel, family, name, ckey)
     console.print(f"[green]Success![/green] Removed [cyan]{target}[/cyan] from '[cyan]{channel}[/cyan]'.")
+
+
+def _show_dotorg(owner: str, token_value, org_site_value) -> None:
+    """Delegate a channel show for an anaconda.org owner to the legacy ``show`` path.
+
+    anaconda.org has no repocore channel metadata; ``anaconda show OWNER`` lists
+    the owner's packages, which is the closest equivalent — the same proxying
+    ``channel upload`` does for owner-only names.
+    """
+    args = argparse.Namespace(
+        token=token_value,
+        site=org_site_value,
+        spec=parse_specs(owner),
+    )
+    show_mod.main(args)
 
 
 def _remove_from_dotorg(owner: str, target: str, token_value, org_site_value, force: bool) -> None:

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -56,6 +56,35 @@ app = typer.Typer(
 )
 
 
+class _DotOrgCredentials(BaseModel):
+    """The ``--token``/``--site`` pair plus the anaconda.org owner probe built from them.
+
+    Shared by the ``show``, ``upload``, and ``remove-package`` commands to route a
+    bare name to anaconda.org (dotorg) when it matches an owner there.
+
+    ``--at`` selects the anaconda.com (repo) domain and is NOT a valid anaconda.org
+    site alias, so only ``--site`` is carried here as ``site``.
+    """
+
+    token: Optional[str] = None
+    site: Optional[str] = None
+
+    @classmethod
+    def from_ctx(cls, ctx) -> "_DotOrgCredentials":
+        """Read ``--token``/``--site`` off the command context's params."""
+        params = getattr(ctx.obj, "params", {})
+        return cls(token=params.get("token"), site=params.get("site"))
+
+    def owner_probe(self, name: str) -> bool:
+        """Whether ``name`` is a real anaconda.org owner (user or organization)."""
+        try:
+            aserver_api = get_server_api(self.token, self.site)
+            aserver_api.user(name)
+            return True
+        except Exception:
+            return False
+
+
 @app.callback(invoke_without_command=True)
 def _callback(
     ctx: typer.Context,
@@ -417,16 +446,16 @@ def show_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    creds = _DotOrgCredentials.from_ctx(ctx)
+    dotorg_creds = _DotOrgCredentials.from_ctx(ctx)
 
     # Classify the name the same way `channel upload`/`remove-package` do: a bare
     # name matching an anaconda.org owner routes to dotorg, otherwise anaconda.com.
-    resolved = classify_and_resolve(api, name, namespace, owner_probe=creds.owner_probe)
+    resolved = classify_and_resolve(api, name, namespace, owner_probe=dotorg_creds.owner_probe)
 
     if resolved.target == "org":
         # anaconda.org packages/files listings don't apply; `anaconda show OWNER`
         # already lists the owner's packages.
-        _show_dotorg(cast(str, resolved.owner), creds.token, creds.site)
+        _show_dotorg(cast(str, resolved.owner), dotorg_creds.token, dotorg_creds.site)
         return
 
     name = f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name
@@ -520,37 +549,6 @@ def modify_command(
         console.print(f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[indexing_behavior]}.")
 
 
-class _DotOrgCredentials(BaseModel):
-    """The ``--token``/``--site`` pair plus the anaconda.org owner probe.
-
-    These always travel together: the probe routes a bare name to dotorg when it
-    matches an anaconda.org owner, and the same token/site then drive the dotorg
-    operation (show/remove/upload) after resolution. Bundling them keeps the
-    per-command wiring to one line and the ``--at`` vs ``--site`` rule in one place.
-
-    Note: ``--at`` selects the anaconda.com (repo) domain and is NOT a valid
-    anaconda.org site alias, so only ``--site`` is carried here as ``site``.
-    """
-
-    token: Optional[str] = None
-    site: Optional[str] = None
-
-    @classmethod
-    def from_ctx(cls, ctx) -> "_DotOrgCredentials":
-        """Read ``--token``/``--site`` off the command context's params."""
-        params = getattr(ctx.obj, "params", {})
-        return cls(token=params.get("token"), site=params.get("site"))
-
-    def owner_probe(self, name: str) -> bool:
-        """Whether ``name`` is a real anaconda.org owner (user or organization)."""
-        try:
-            aserver_api = get_server_api(self.token, self.site)
-            aserver_api.user(name)
-            return True
-        except Exception:
-            return False
-
-
 def _do_upload(
     api,
     files: List[str],
@@ -558,7 +556,7 @@ def _do_upload(
     namespace: Optional[str],
     package_type: Optional[str],
     from_deprecated_channel_flag: bool,
-    creds: "_DotOrgCredentials",
+    dotorg_creds: _DotOrgCredentials,
     labels: Optional[List[str]] = None,
     org_upload_args: object = None,
 ) -> None:
@@ -578,7 +576,7 @@ def _do_upload(
         raise typer.Exit(1)
 
     resolved = _resolve_channels_with_namespaces(
-        api, channels, namespace, from_deprecated_channel_flag, owner_probe=creds.owner_probe
+        api, channels, namespace, from_deprecated_channel_flag, owner_probe=dotorg_creds.owner_probe
     )
 
     org_targets = [r for r in resolved if r.target == "org"]
@@ -624,9 +622,8 @@ def upload_command(
         from binstar_client import __version__
 
         # Carry --site/--token from the `anaconda upload` bridge, if provided.
-        # `anaconda upload --site` is an anaconda.org alias (see _DotOrgCredentials).
         site_value = getattr(org_upload_args, "site", None)
-        creds = _DotOrgCredentials(token=getattr(org_upload_args, "token", None), site=site_value)
+        dotorg_creds = _DotOrgCredentials(token=getattr(org_upload_args, "token", None), site=site_value)
 
         ctx_obj = ContextExtras()
         ctx_obj.repo_api = RepoCoreClient(site=site_value, version=__version__)
@@ -636,7 +633,7 @@ def upload_command(
 
         ctx = FakeContext()
     else:
-        creds = _DotOrgCredentials.from_ctx(ctx)
+        dotorg_creds = _DotOrgCredentials.from_ctx(ctx)
 
     _do_upload(
         ctx.obj.repo_api,
@@ -645,7 +642,7 @@ def upload_command(
         namespace,
         package_type,
         from_deprecated_channel_flag,
-        creds,
+        dotorg_creds,
         labels=labels,
         org_upload_args=org_upload_args,
     )
@@ -693,7 +690,7 @@ def _upload_cli(
         namespace,
         package_type.value if package_type else None,
         from_deprecated_channel_flag=False,
-        creds=_DotOrgCredentials.from_ctx(ctx),
+        dotorg_creds=_DotOrgCredentials.from_ctx(ctx),
         labels=label or [],
     )
 
@@ -979,14 +976,14 @@ def remove_package_command(
         raise typer.Exit(1)
 
     api = ctx.obj.repo_api
-    creds = _DotOrgCredentials.from_ctx(ctx)
+    dotorg_creds = _DotOrgCredentials.from_ctx(ctx)
 
     # Classify the -c target the same way `channel upload` does: a bare name that
     # matches an anaconda.org owner routes to dotorg, otherwise anaconda.com.
-    resolved = classify_and_resolve(api, channels[0], namespace, owner_probe=creds.owner_probe)
+    resolved = classify_and_resolve(api, channels[0], namespace, owner_probe=dotorg_creds.owner_probe)
 
     if resolved.target == "org":
-        _remove_from_dotorg(cast(str, resolved.owner), target, creds.token, creds.site, force)
+        _remove_from_dotorg(cast(str, resolved.owner), target, dotorg_creds.token, dotorg_creds.site, force)
         return
 
     channel_path = f"{resolved.namespace}/{resolved.channel_name}" if resolved.namespace else resolved.channel_name

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -2,6 +2,8 @@
 
 from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCoreClient
 from binstar_client.repocore.models import (
+    Artifact,
+    ArtifactFile,
     Channel,
     ChannelCreationResponse,
     Namespace,
@@ -12,6 +14,8 @@ __all__ = [
     "REPO_API_PATH",
     "AUTH_API_PATH",
     "RepoCoreClient",
+    "Artifact",
+    "ArtifactFile",
     "Channel",
     "ChannelCreationResponse",
     "Namespace",

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -11,6 +11,8 @@ from anaconda_auth.client import BaseClient
 
 from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthorized
 from binstar_client.repocore.models import (
+    Artifact,
+    ArtifactFile,
     Channel,
     ChannelCreationResponse,
     Namespace,
@@ -231,6 +233,81 @@ class RepoCoreClient(BaseClient):
             response = self.post(url, files=multipart_form_data)
 
         return self._manage_response(response, f"uploading {filename}", success_codes=[200, 201])
+
+    def _artifacts_url(self, channel: str) -> str:
+        """Base ``.../artifacts`` URL for a channel or subchannel.
+
+        Reuses ``_get_channel_url`` so subchannels resolve to the
+        ``/channels/{parent}/subchannels/{sub}`` form the server expects.
+        """
+        return join(self._get_channel_url(channel), "artifacts")
+
+    def list_artifacts(
+        self,
+        channel: str,
+        offset: int = 0,
+        limit: int = 100,
+        query: Optional[str] = None,
+        artifact_family: Optional[str] = None,
+        platform: Optional[str] = None,
+        sort: Optional[str] = None,
+    ) -> tuple[list[Artifact], int]:
+        """List packages (artifacts) in a channel.
+
+        Each item is a *package* grouped by family + name — not an individual
+        file. Returns the page of artifacts and the server's total count.
+        """
+        params: dict = {"offset": offset, "limit": limit}
+        if query:
+            params["q"] = query
+        if artifact_family:
+            params["artifact_family"] = artifact_family
+        if platform:
+            params["platform"] = platform
+        if sort:
+            params["sort"] = sort
+
+        response = self.get(self._artifacts_url(channel), params=params)
+        data = self._manage_response(response, f"listing artifacts in {channel}")
+        items = [Artifact(**item) for item in data.get("items", [])]
+        return items, data.get("total_count", len(items))
+
+    def list_artifact_files(
+        self,
+        channel: str,
+        artifact_family: str,
+        artifact_name: str,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> tuple[list[ArtifactFile], int]:
+        """List the individual files of a package in a channel."""
+        url = join(self._artifacts_url(channel), artifact_family, artifact_name, "files")
+        response = self.get(url, params={"offset": offset, "limit": limit})
+        data = self._manage_response(
+            response, f"listing files for {artifact_family}/{artifact_name} in {channel}"
+        )
+        items = [ArtifactFile(**item) for item in data.get("items", [])]
+        return items, data.get("total_count", len(items))
+
+    def delete_artifact_file(self, channel: str, artifact_family: str, artifact_name: str, ckey: str):
+        """Delete a single file (identified by ``ckey``) from a channel.
+
+        Uses the bulk endpoint with a ``ckey`` so only that one file (route) is
+        removed, rather than the whole package that ``DELETE .../{family}/{name}``
+        would drop. Returns on the server's 202 Accepted.
+        """
+        url = join(self._artifacts_url(channel), "bulk")
+        data = {
+            "action": "delete",
+            "items": [{"name": artifact_name, "family": artifact_family, "ckey": ckey}],
+        }
+        response = self.put(url, json=data)
+        return self._manage_response(
+            response,
+            f"removing {ckey} from {channel}",
+            success_codes=[200, 202, 204],
+            empty_success_codes=[200, 202, 204],
+        )
 
     def share_channel(self, namespace: str, channel_name: str, user: str, action: str = "share", grant: str = "read"):
         url = join(self._api_base, "namespaces", namespace, "channels", channel_name, "sharing")

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -323,7 +323,9 @@ class RepoCoreClient(BaseClient):
         """List the individual files of a package in a channel."""
         url = join(self._artifacts_url(channel), artifact_family, artifact_name, "files")
         response = self.get(url, params={"offset": offset, "limit": limit})
-        data, error = self._manage_response(response, f"listing files for {artifact_family}/{artifact_name} in {channel}")
+        data, error = self._manage_response(
+            response, f"listing files for {artifact_family}/{artifact_name} in {channel}"
+        )
         if error:
             raise error
         items = [ArtifactFile(**item) for item in data.get("items", [])]

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -283,9 +283,7 @@ class RepoCoreClient(BaseClient):
         """List the individual files of a package in a channel."""
         url = join(self._artifacts_url(channel), artifact_family, artifact_name, "files")
         response = self.get(url, params={"offset": offset, "limit": limit})
-        data = self._manage_response(
-            response, f"listing files for {artifact_family}/{artifact_name} in {channel}"
-        )
+        data = self._manage_response(response, f"listing files for {artifact_family}/{artifact_name} in {channel}")
         items = [ArtifactFile(**item) for item in data.get("items", [])]
         return items, data.get("total_count", len(items))
 

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -63,6 +63,53 @@ class Channel(BaseModel):
         return f"{self.parent}/{self.name}" if self.parent else self.name
 
 
+class Artifact(BaseModel):
+    """A package in a channel, as returned by ``GET .../artifacts``.
+
+    An "artifact" here is a *package* — the server groups files by
+    ``family`` + ``name`` (its common name), so one Artifact spans every
+    version and file of that package in the channel. Individual files live one
+    level down (see :class:`ArtifactFile`).
+    """
+
+    name: str
+    family: str = ""
+    channel: str = ""
+    subchannel: str = ""
+    download_count: int = 0
+    file_count: int = 0
+    cve_count: int = 0
+    available_versions: list[str] = Field(default_factory=list)
+    updated_at: str = ""
+
+    @field_validator("available_versions", mode="before")
+    @classmethod
+    def _none_versions_as_empty(cls, v):
+        return v or []
+
+
+class ArtifactFile(BaseModel):
+    """A single physical file (route) belonging to an artifact/package.
+
+    Identified by ``ckey``, the file's route path (e.g.
+    ``linux-64/numpy-2.2.5-py313h51bfb38_3.conda`` or
+    ``simple/six/six-1.12.0-py2.py3-none-any.whl``). The filename a user works
+    with is the basename of the ckey.
+    """
+
+    ckey: str = ""
+    name: str = ""
+    family: str = ""
+    channel: str = ""
+    subchannel: str = ""
+    size: int = 0
+
+    @property
+    def filename(self) -> str:
+        """The bare filename — the last path segment of the ckey."""
+        return self.ckey.rsplit("/", 1)[-1] if self.ckey else ""
+
+
 class ChannelCreationResponse(BaseModel):
     """Response from creating a namespace channel."""
 

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -63,7 +63,11 @@ def _iter_readable_channels(api):
     """
     offset = 0
     while True:
-        channels, total = api.list_all_channels(offset=offset, limit=_CHANNEL_PAGE_SIZE, include_subchannels=True)
+        channels, total, error = api.list_all_channels(
+            offset=offset, limit=_CHANNEL_PAGE_SIZE, include_subchannels=True
+        )
+        if error:
+            raise error
         yield from channels
         offset += len(channels)
         # Stop on an empty/short page too, so an over-reported total can't loop forever.

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -50,6 +50,41 @@ def _org_channel(owner: str, channel_name: str) -> ResolvedChannel:
     )
 
 
+_CHANNEL_PAGE_SIZE = 100
+
+
+def _iter_readable_channels(api):
+    """Yield every channel the caller can read (own + shared), paging ``GET /channels``.
+
+    ``include_subchannels=True`` so the listing carries both top-level channels
+    (a namespace: ``parent is None``) and subchannels (an actual channel, whose
+    namespace is its ``parent``). The server scopes the result to the token's
+    permissions, so this spans the user's own channels plus any shared with it.
+    """
+    offset = 0
+    while True:
+        channels, total = api.list_all_channels(offset=offset, limit=_CHANNEL_PAGE_SIZE, include_subchannels=True)
+        yield from channels
+        offset += len(channels)
+        # Stop on an empty/short page too, so an over-reported total can't loop forever.
+        if not channels or len(channels) < _CHANNEL_PAGE_SIZE or offset >= total:
+            break
+
+
+def _readable_namespaces(channels) -> List[str]:
+    """The distinct namespaces present in a readable-channel listing.
+
+    A top-level channel is itself a namespace; a subchannel's namespace is its
+    ``parent``. Order is preserved and duplicates dropped so the picker is stable.
+    """
+    namespaces: List[str] = []
+    for channel in channels:
+        ns = channel.namespace or channel.name
+        if ns not in namespaces:
+            namespaces.append(ns)
+    return namespaces
+
+
 def resolve_no_namespace(api, name: str) -> ResolvedChannel:
     """Resolve the no-namespaces case.
 
@@ -86,8 +121,12 @@ def resolve_namespace_and_channel(
       1. name contains "/" AND --namespace provided → error (ambiguous)
       2. name contains "/" → split into namespace/channel
       3. --namespace provided → use it, name is the channel
-      4. Neither → resolve namespace from API via user's top-level channels
-      5. Calls resolve_no_namespace if none are present
+      4. Neither → match the bare name against readable subchannels (own +
+         shared): exactly one match resolves to that namespace/channel directly,
+         several prompt among the full paths
+      5. No existing subchannel matches → resolve the namespace instead (one
+         auto-resolves, several prompt), so a new channel name still resolves
+      6. Calls resolve_no_namespace if no namespaces are present
     """
     if "/" in name and namespace:
         console.print(f"[red]Error:[/red] Ambiguous: '{name}' contains '/' but --namespace was also provided.")
@@ -100,9 +139,30 @@ def resolve_namespace_and_channel(
     if namespace:
         return _repo_channel(namespace=namespace, channel_name=name)
 
-    # Resolve from API
-    orgs = api.list_user_organizations()
-    namespaces = [org.name for org in orgs]
+    # List every channel the caller can read — its own *and* any shared with it —
+    # so both existing-channel matching and namespace resolution see shared items.
+    channels = list(_iter_readable_channels(api))
+
+    # First, does the bare name already name a subchannel? A subchannel is an
+    # actual channel (has a parent namespace); a top-level channel is a namespace,
+    # not a channel target. If exactly one subchannel matches, resolve it directly
+    # even when several namespaces exist — it's unambiguous (e.g. dude/imhungry).
+    subchannel_matches = [c for c in channels if c.namespace and c.name == name]
+    if len(subchannel_matches) == 1:
+        chosen = subchannel_matches[0]
+        return _repo_channel(namespace=chosen.namespace, channel_name=chosen.name)
+    if len(subchannel_matches) > 1:
+        # The same channel name under more than one readable namespace: disambiguate
+        # by full path (e.g. dude/imhungry vs fluffybunnies/imhungry).
+        console.print()
+        paths = [c.path for c in subchannel_matches]
+        selected_path = select_from_list(f"Select channel for '{name}':", paths)
+        chosen = next(c for c in subchannel_matches if c.path == selected_path)
+        return _repo_channel(namespace=chosen.namespace, channel_name=chosen.name)
+
+    # No existing channel by that name — resolve the namespace it should live
+    # under, so a brand-new channel name (e.g. `create`) still resolves.
+    namespaces = _readable_namespaces(channels)
 
     if not namespaces:
         if require_namespace:
@@ -160,8 +220,8 @@ def classify_and_resolve(
     never a namespace: we find which namespace it lives under. When a bare name also
     names an anaconda.org owner, we disambiguate:
 
-      * matches an anaconda.org owner AND an anaconda.com namespace -> prompt
-      * matches only an anaconda.org owner                          -> target="org"
+      * matches an anaconda.org owner AND a readable anaconda.com namespace -> prompt
+      * matches only an anaconda.org owner                                  -> target="org"
       * otherwise -> anaconda.com channel resolution (existing behavior)
 
     Returns a ResolvedChannel whose ``target`` field says which system to use.
@@ -174,9 +234,14 @@ def classify_and_resolve(
 
     repo_match = False
     if org_match:
-        # Only need the (possibly expensive) namespace list to detect a collision.
+        # Only fetch the (possibly expensive) channel listing to detect a real
+        # collision — where the bare name already *names* something on anaconda.com:
+        # a top-level namespace, or an existing readable subchannel by that name.
+        # The namespace *fallback* (placing a brand-new channel under some namespace)
+        # is not a collision: with no such name present, an org owner routes to org.
         try:
-            repo_match = any(org.name == name for org in api.list_user_organizations())
+            channels = list(_iter_readable_channels(api))
+            repo_match = any(c.name == name for c in channels)
         except Exception:
             repo_match = False
 

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1678,6 +1678,54 @@ class TestRepoCoreViewAndRemove:
         assert result.exit_code == 1
         assert "No channel specified" in result.output
 
+    def test_remove_package_routes_to_dotorg_for_owner(self):
+        """A -c value matching an anaconda.org owner proxies to the legacy remove path."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        with (
+            # owner_exists=True makes the owner probe report an anaconda.org owner,
+            # so classify_and_resolve routes the bare name to target="org".
+            _patch_repo_api(mock_api, owner_exists=True),
+            patch("binstar_client.commands.remove.main") as mock_remove_main,
+        ):
+            result = runner.invoke(
+                app,
+                ["remove-package", "mypkg/1.0/mypkg-1.0.tar.bz2", "-c", "someowner", "--force"],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Delegated to dotorg, not the repocore file delete.
+        mock_api.delete_artifact_file.assert_not_called()
+        mock_remove_main.assert_called_once()
+        args = mock_remove_main.call_args[0][0]
+        assert args.force is True
+        # The owner is prepended to form the full owner/package/version/filename spec.
+        spec = args.specs[0]
+        assert spec.user == "someowner"
+        assert spec.package == "mypkg"
+
+    def test_remove_package_owner_prepended_once(self):
+        """If the target already starts with the owner, it is not doubled."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        with (
+            _patch_repo_api(mock_api, owner_exists=True),
+            patch("binstar_client.commands.remove.main") as mock_remove_main,
+        ):
+            result = runner.invoke(
+                app,
+                ["remove-package", "someowner/mypkg/1.0/mypkg-1.0.tar.bz2", "-c", "someowner", "--force"],
+            )
+
+        assert result.exit_code == 0, result.output
+        spec = mock_remove_main.call_args[0][0].specs[0]
+        assert spec.user == "someowner"
+        assert spec.package == "mypkg"
+
 
 class TestPackageUtils:
     def test_windows_glob_on_windows(self):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1697,6 +1697,8 @@ class TestRepoCoreViewAndRemove:
         spec = args.specs[0]
         assert spec.user == "someowner"
         assert spec.package == "mypkg"
+        assert spec.version == "1.0"
+        assert spec.basename == "mypkg-1.0.tar.bz2"
 
     def test_remove_package_owner_prepended_once(self):
         """If the target already starts with the owner, it is not doubled."""
@@ -1717,6 +1719,64 @@ class TestRepoCoreViewAndRemove:
         spec = mock_remove_main.call_args[0][0].specs[0]
         assert spec.user == "someowner"
         assert spec.package == "mypkg"
+        assert spec.version == "1.0"
+        assert spec.basename == "mypkg-1.0.tar.bz2"
+
+    def test_view_pages_through_all_artifacts(self):
+        """view keeps requesting pages until the reported total is reached."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        # Two full pages of 100 then a short final page; total is 250.
+        page1 = ([self._artifact(name=f"pkg{i}", family="conda") for i in range(100)], 250)
+        page2 = ([self._artifact(name=f"pkg{i}", family="conda") for i in range(100, 200)], 250)
+        page3 = ([self._artifact(name=f"pkg{i}", family="conda") for i in range(200, 250)], 250)
+        mock_api.list_artifacts.side_effect = [page1, page2, page3]
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_api.list_artifacts.call_count == 3
+        offsets = [call.kwargs["offset"] for call in mock_api.list_artifacts.call_args_list]
+        assert offsets == [0, 100, 200]
+
+    def test_view_stops_on_short_page_despite_overreported_total(self):
+        """A total larger than the data still terminates once a short page arrives."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        # Server over-reports total=999 but only returns a short first page.
+        mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 999)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+
+        assert result.exit_code == 0, result.output
+        # Short page (1 < _PAGE_SIZE) ends paging; no infinite loop.
+        assert mock_api.list_artifacts.call_count == 1
+
+    def test_remove_package_ambiguous_match(self):
+        """A filename resolving to more than one file aborts without deleting."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = (
+            [self._artifact(name="numpy", family="conda"), self._artifact(name="numpy2", family="conda")],
+            2,
+        )
+        # Same bare filename appears under two different packages/subdirs.
+        mock_api.list_artifact_files.side_effect = [
+            ([self._file(ckey="linux-64/dup.conda", name="numpy", family="conda")], 1),
+            ([self._file(ckey="win-64/dup.conda", name="numpy2", family="conda")], 1),
+        ]
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["remove-package", "dup.conda", "-c", "myns/dev", "--force"])
+
+        assert result.exit_code == 1
+        assert "matches more than one file" in result.output
+        mock_api.delete_artifact_file.assert_not_called()
 
 
 class TestPackageUtils:

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -390,9 +390,7 @@ class TestRepoCoreArtifacts:
         assert call_url.endswith("/artifacts/bulk")
         body = client.put.call_args[1]["json"]
         assert body["action"] == "delete"
-        assert body["items"] == [
-            {"name": "numpy", "family": "conda", "ckey": "linux-64/numpy-2.2.5-py313.conda"}
-        ]
+        assert body["items"] == [{"name": "numpy", "family": "conda", "ckey": "linux-64/numpy-2.2.5-py313.conda"}]
 
     def test_delete_artifact_file_unauthorized(self):
         client = _make_client()
@@ -1622,9 +1620,7 @@ class TestRepoCoreViewAndRemove:
         )
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(
-                app, ["remove-package", "numpy-2.2.5-py313.conda", "-c", "myns/dev", "--force"]
-            )
+            result = runner.invoke(app, ["remove-package", "numpy-2.2.5-py313.conda", "-c", "myns/dev", "--force"])
 
         assert result.exit_code == 0, result.output
         mock_api.delete_artifact_file.assert_called_once_with(
@@ -1644,9 +1640,7 @@ class TestRepoCoreViewAndRemove:
 
         with _patch_repo_api(mock_api):
             # Answer "n" to the confirmation prompt.
-            result = runner.invoke(
-                app, ["remove-package", "numpy-2.2.5-py313.conda", "-c", "myns/dev"], input="n\n"
-            )
+            result = runner.invoke(app, ["remove-package", "numpy-2.2.5-py313.conda", "-c", "myns/dev"], input="n\n")
 
         assert result.exit_code == 0
         mock_api.delete_artifact_file.assert_not_called()
@@ -1662,9 +1656,7 @@ class TestRepoCoreViewAndRemove:
         )
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(
-                app, ["remove-package", "does-not-exist.conda", "-c", "myns/dev", "--force"]
-            )
+            result = runner.invoke(app, ["remove-package", "does-not-exist.conda", "-c", "myns/dev", "--force"])
 
         assert result.exit_code == 1
         assert "No file named" in result.output

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -27,7 +27,7 @@ def _namespace_channels(*names):
     The resolver derives namespaces from the top-level channels the user can
     read; a single unpaged page is enough for tests.
     """
-    return ([Channel(name=n, privacy="private") for n in names], len(names))
+    return ([Channel(name=n, privacy="private") for n in names], len(names), None)
 
 
 def _readable_channels(*channels):
@@ -37,7 +37,7 @@ def _readable_channels(*channels):
     parent makes it a subchannel under that namespace.
     """
     items = [Channel(name=name, privacy="private", parent=parent) for name, parent in channels]
-    return (items, len(items))
+    return (items, len(items), None)
 
 
 class TestPydanticModels:
@@ -544,9 +544,9 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        page1 = ([Channel(name=f"ns{i}", privacy="private") for i in range(100)], 150)
+        page1 = ([Channel(name=f"ns{i}", privacy="private") for i in range(100)], 150, None)
         # Second page repeats ns0 (dedup) and adds ns100 (the sole *new* namespace).
-        page2 = ([Channel(name="ns0", privacy="private"), Channel(name="ns100", privacy="private")], 150)
+        page2 = ([Channel(name="ns0", privacy="private"), Channel(name="ns100", privacy="private")], 150, None)
         mock_api.list_all_channels.side_effect = [page1, page2]
 
         with patch("binstar_client.repocore.resolve.select_from_list", return_value="ns100") as sel:

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -344,6 +344,64 @@ class TestRepoCoreNamespaceChannel:
         assert "grant" not in call_args[1]["json"]
 
 
+class TestRepoCoreArtifacts:
+    def test_list_artifacts(self):
+        client = _make_client()
+        payload = {
+            "total_count": 2,
+            "items": [
+                {"name": "numpy", "family": "conda", "file_count": 3, "available_versions": ["1.0", "2.0"]},
+                {"name": "flask", "family": "python", "download_count": 7},
+            ],
+        }
+        client.get = MagicMock(return_value=_mock_response(200, payload))
+
+        items, total = client.list_artifacts("myns/dev", query="num")
+
+        assert total == 2
+        assert [a.name for a in items] == ["numpy", "flask"]
+        call_url = client.get.call_args[0][0]
+        # Subchannel arg routes through /subchannels/ and appends /artifacts.
+        assert call_url.endswith("/channels/myns/subchannels/dev/artifacts")
+        assert client.get.call_args[1]["params"]["q"] == "num"
+
+    def test_list_artifact_files(self):
+        client = _make_client()
+        payload = {
+            "total_count": 1,
+            "items": [{"ckey": "linux-64/numpy-2.2.5-py313.conda", "name": "numpy", "family": "conda", "size": 100}],
+        }
+        client.get = MagicMock(return_value=_mock_response(200, payload))
+
+        items, total = client.list_artifact_files("myns/dev", "conda", "numpy")
+
+        assert total == 1
+        assert items[0].filename == "numpy-2.2.5-py313.conda"
+        call_url = client.get.call_args[0][0]
+        assert call_url.endswith("/channels/myns/subchannels/dev/artifacts/conda/numpy/files")
+
+    def test_delete_artifact_file_uses_bulk_with_ckey(self):
+        client = _make_client()
+        client.put = MagicMock(return_value=_mock_response(202, None))
+
+        client.delete_artifact_file("myns/dev", "conda", "numpy", "linux-64/numpy-2.2.5-py313.conda")
+
+        call_url = client.put.call_args[0][0]
+        assert call_url.endswith("/artifacts/bulk")
+        body = client.put.call_args[1]["json"]
+        assert body["action"] == "delete"
+        assert body["items"] == [
+            {"name": "numpy", "family": "conda", "ckey": "linux-64/numpy-2.2.5-py313.conda"}
+        ]
+
+    def test_delete_artifact_file_unauthorized(self):
+        client = _make_client()
+        client.put = MagicMock(return_value=_mock_response(403, None))
+
+        with pytest.raises(Unauthorized):
+            client.delete_artifact_file("myns/dev", "conda", "numpy", "linux-64/numpy.conda")
+
+
 class TestResolveNamespaceAndChannel:
     def test_slash_in_name_extracts_both(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
@@ -1476,6 +1534,149 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 1
         assert "Ambiguous" in result.output
         mock_api.share_channel.assert_not_called()
+
+
+class TestRepoCoreViewAndRemove:
+    def _artifact(self, **kw):
+        from binstar_client.repocore import Artifact
+
+        return Artifact(**kw)
+
+    def _file(self, **kw):
+        from binstar_client.repocore import ArtifactFile
+
+        return ArtifactFile(**kw)
+
+    def test_view_requires_channel(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        with _patch_repo_api(MagicMock()):
+            result = runner.invoke(app, ["view", "--packages"])
+        assert result.exit_code == 1
+        assert "No channel specified" in result.output
+
+    def test_view_packages_summary(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = (
+            [self._artifact(name="numpy", family="conda", file_count=3, available_versions=["1.0", "2.0"])],
+            1,
+        )
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+
+        assert result.exit_code == 0, result.output
+        assert "numpy" in result.output
+        mock_api.list_artifacts.assert_called_with("myns/dev", offset=0, limit=100)
+
+    def test_view_defaults_to_packages(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 1)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["view", "-c", "myns/dev"])
+
+        assert result.exit_code == 0, result.output
+        assert "numpy" in result.output
+
+    def test_view_files_shows_filenames(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 1)
+        mock_api.list_artifact_files.return_value = (
+            [self._file(ckey="linux-64/numpy-2.2.5-py313.conda", name="numpy", family="conda", size=1048576)],
+            1,
+        )
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["view", "-c", "myns/dev", "--files"])
+
+        assert result.exit_code == 0, result.output
+        assert "numpy-2.2.5-py313.conda" in result.output
+
+    def test_view_empty_channel(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = ([], 0)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+
+        assert result.exit_code == 0, result.output
+        assert "No packages found" in result.output
+
+    def test_remove_package_success(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 1)
+        mock_api.list_artifact_files.return_value = (
+            [self._file(ckey="linux-64/numpy-2.2.5-py313.conda", name="numpy", family="conda")],
+            1,
+        )
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(
+                app, ["remove-package", "numpy-2.2.5-py313.conda", "-c", "myns/dev", "--force"]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_api.delete_artifact_file.assert_called_once_with(
+            "myns/dev", "conda", "numpy", "linux-64/numpy-2.2.5-py313.conda"
+        )
+        assert "Success" in result.output
+
+    def test_remove_package_prompts_without_force(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 1)
+        mock_api.list_artifact_files.return_value = (
+            [self._file(ckey="linux-64/numpy-2.2.5-py313.conda", name="numpy", family="conda")],
+            1,
+        )
+
+        with _patch_repo_api(mock_api):
+            # Answer "n" to the confirmation prompt.
+            result = runner.invoke(
+                app, ["remove-package", "numpy-2.2.5-py313.conda", "-c", "myns/dev"], input="n\n"
+            )
+
+        assert result.exit_code == 0
+        mock_api.delete_artifact_file.assert_not_called()
+
+    def test_remove_package_not_found(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 1)
+        mock_api.list_artifact_files.return_value = (
+            [self._file(ckey="linux-64/numpy-2.2.5-py313.conda", name="numpy", family="conda")],
+            1,
+        )
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(
+                app, ["remove-package", "does-not-exist.conda", "-c", "myns/dev", "--force"]
+            )
+
+        assert result.exit_code == 1
+        assert "No file named" in result.output
+        mock_api.delete_artifact_file.assert_not_called()
+
+    def test_remove_package_requires_channel(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        with _patch_repo_api(MagicMock()):
+            result = runner.invoke(app, ["remove-package", "foo.conda", "--force"])
+        assert result.exit_code == 1
+        assert "No channel specified" in result.output
 
 
 class TestPackageUtils:

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1718,6 +1718,54 @@ class TestRepoCoreShowListingAndRemove:
         spec = mock_show_main.call_args[0][0].spec
         assert spec.user == "someowner"
 
+    def test_show_dotorg_configures_binstar_console_logging(self):
+        """Delegating to legacy show must configure the binstar logger for console.
+
+        legacy ``show.main`` prints its listing via ``logging`` at INFO. Under the
+        ``channel`` Typer app nothing configures that logger, so without the fix
+        the INFO records are dropped and the command prints nothing. Assert that,
+        by the time show.main runs, the ``binstar`` logger is emitting at INFO
+        with a console (StreamHandler) attached so its output is not swallowed.
+        """
+        import logging
+
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        binstar_logger = logging.getLogger("binstar")
+        # Start from the unconfigured state the bug depends on.
+        original_handlers = binstar_logger.handlers[:]
+        original_level = binstar_logger.level
+        for handler in original_handlers:
+            binstar_logger.removeHandler(handler)
+        binstar_logger.setLevel(logging.NOTSET)
+
+        seen = {}
+
+        def _fake_show_main(args):
+            show_logger = logging.getLogger("binstar.show")
+            seen["effective_level"] = show_logger.getEffectiveLevel()
+            seen["has_stream_handler"] = any(isinstance(h, logging.StreamHandler) for h in binstar_logger.handlers)
+
+        try:
+            with (
+                _patch_repo_api(mock_api, owner_exists=True),
+                patch("binstar_client.commands.show.main", side_effect=_fake_show_main),
+            ):
+                result = runner.invoke(app, ["show", "someowner"])
+        finally:
+            for handler in binstar_logger.handlers[:]:
+                binstar_logger.removeHandler(handler)
+            for handler in original_handlers:
+                binstar_logger.addHandler(handler)
+            binstar_logger.setLevel(original_level)
+
+        assert result.exit_code == 0, result.output
+        # INFO records from show.main will not be dropped, and go to a console.
+        assert seen["effective_level"] <= logging.INFO
+        assert seen["has_stream_handler"] is True
+
     def test_show_packages_summary(self):
         runner = CliRunner()
         app = _get_channels_app()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -20,6 +20,25 @@ from binstar_client.repocore.errors import (
 )
 
 
+def _namespace_channels(*names):
+    """Build a ``list_all_channels`` return value from top-level channel names.
+
+    The resolver derives namespaces from the top-level channels the user can
+    read; a single unpaged page is enough for tests.
+    """
+    return ([Channel(name=n, privacy="private") for n in names], len(names))
+
+
+def _readable_channels(*channels):
+    """Build a ``list_all_channels`` return value from ``(name, parent)`` pairs.
+
+    A ``parent`` of ``None`` is a top-level channel (a namespace); a non-None
+    parent makes it a subchannel under that namespace.
+    """
+    items = [Channel(name=name, privacy="private", parent=parent) for name, parent in channels]
+    return (items, len(items))
+
+
 class TestPydanticModels:
     def test_namespace_model(self):
         ns = Namespace(name="test-org")
@@ -408,7 +427,7 @@ class TestResolveNamespaceAndChannel:
         resolved = _resolve_namespace_and_channel(mock_api, "myorg/dev")
         assert resolved.namespace == "myorg"
         assert resolved.channel_name == "dev"
-        mock_api.list_user_organizations.assert_not_called()
+        mock_api.list_all_channels.assert_not_called()
 
     def test_explicit_namespace_flag(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
@@ -417,7 +436,7 @@ class TestResolveNamespaceAndChannel:
         resolved = _resolve_namespace_and_channel(mock_api, "dev", namespace="myorg")
         assert resolved.namespace == "myorg"
         assert resolved.channel_name == "dev"
-        mock_api.list_user_organizations.assert_not_called()
+        mock_api.list_all_channels.assert_not_called()
 
     def test_ambiguous_slash_and_flag_exits(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
@@ -431,7 +450,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
         resolved = _resolve_namespace_and_channel(mock_api, "dev")
         assert resolved.namespace == "myorg"
         assert resolved.channel_name == "dev"
@@ -441,7 +460,7 @@ class TestResolveNamespaceAndChannel:
         from click.exceptions import Exit
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = []
+        mock_api.list_all_channels.return_value = _namespace_channels()
         with pytest.raises(Exit):
             _resolve_namespace_and_channel(mock_api, "dev")
 
@@ -449,16 +468,116 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [
-            Namespace(name="org-a"),
-            Namespace(name="org-b"),
-        ]
+        mock_api.list_all_channels.return_value = _namespace_channels("org-a", "org-b")
 
         with patch("binstar_client.repocore.resolve.select_from_list", return_value="org-b"):
             resolved = _resolve_namespace_and_channel(mock_api, "dev")
 
         assert resolved.namespace == "org-b"
         assert resolved.channel_name == "dev"
+
+    def test_namespaces_sourced_from_readable_channels(self):
+        """Namespaces come from GET /channels (own + shared), not org memberships."""
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        # A channel shared from an org the user is not a member of is still offered.
+        mock_api.list_all_channels.return_value = _namespace_channels("shared-org")
+
+        resolved = _resolve_namespace_and_channel(mock_api, "dev")
+
+        assert resolved.namespace == "shared-org"
+        assert resolved.channel_name == "dev"
+        # Resolution uses the readable-channels listing (which includes subchannels
+        # so an existing channel by that name can be matched directly), and never
+        # the org-membership endpoint.
+        assert mock_api.list_all_channels.call_args.kwargs["include_subchannels"] is True
+        mock_api.list_user_organizations.assert_not_called()
+
+    def test_namespaces_paged_and_deduped(self):
+        """Namespace resolution pages GET /channels and drops duplicate namespaces."""
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        page1 = ([Channel(name=f"ns{i}", privacy="private") for i in range(100)], 150)
+        # Second page repeats ns0 (dedup) and adds ns100 (the sole *new* namespace).
+        page2 = ([Channel(name="ns0", privacy="private"), Channel(name="ns100", privacy="private")], 150)
+        mock_api.list_all_channels.side_effect = [page1, page2]
+
+        with patch("binstar_client.repocore.resolve.select_from_list", return_value="ns100") as sel:
+            resolved = _resolve_namespace_and_channel(mock_api, "dev")
+
+        assert resolved.namespace == "ns100"
+        # Two pages fetched; the picker saw 101 distinct namespaces (ns0..ns100, no dup).
+        assert mock_api.list_all_channels.call_count == 2
+        assert len(sel.call_args[0][1]) == 101
+
+    def test_existing_subchannel_resolves_directly(self):
+        """A bare name matching exactly one readable subchannel resolves with no prompt.
+
+        Even when several namespaces exist, ``imhungry`` living only under ``dude``
+        is unambiguous → ``dude/imhungry`` directly.
+        """
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        mock_api.list_all_channels.return_value = _readable_channels(
+            ("dude", None),
+            ("fluffybunnies", None),
+            ("imhungry", "dude"),
+        )
+
+        with patch("binstar_client.repocore.resolve.select_from_list") as sel:
+            resolved = _resolve_namespace_and_channel(mock_api, "imhungry")
+
+        assert resolved.namespace == "dude"
+        assert resolved.channel_name == "imhungry"
+        sel.assert_not_called()
+
+    def test_ambiguous_subchannel_prompts_full_paths(self):
+        """The same channel name under multiple namespaces prompts among full paths."""
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        mock_api.list_all_channels.return_value = _readable_channels(
+            ("dude", None),
+            ("fluffybunnies", None),
+            ("imhungry", "dude"),
+            ("imhungry", "fluffybunnies"),
+        )
+
+        with patch(
+            "binstar_client.repocore.resolve.select_from_list",
+            return_value="fluffybunnies/imhungry",
+        ) as sel:
+            resolved = _resolve_namespace_and_channel(mock_api, "imhungry")
+
+        assert resolved.namespace == "fluffybunnies"
+        assert resolved.channel_name == "imhungry"
+        # The picker is offered the full paths, not the bare namespaces.
+        assert set(sel.call_args[0][1]) == {"dude/imhungry", "fluffybunnies/imhungry"}
+
+    def test_unknown_name_falls_back_to_namespace_picker(self):
+        """A name matching no existing subchannel resolves a namespace (create path)."""
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        mock_api.list_all_channels.return_value = _readable_channels(
+            ("dude", None),
+            ("fluffybunnies", None),
+            ("imhungry", "dude"),
+        )
+
+        with patch(
+            "binstar_client.repocore.resolve.select_from_list",
+            return_value="fluffybunnies",
+        ) as sel:
+            resolved = _resolve_namespace_and_channel(mock_api, "brandnew")
+
+        assert resolved.namespace == "fluffybunnies"
+        assert resolved.channel_name == "brandnew"
+        # No existing channel matched, so the picker offers namespaces to create under.
+        assert set(sel.call_args[0][1]) == {"dude", "fluffybunnies"}
 
     def test_no_namespaces_with_username_confirmed(self):
         from binstar_client.commands._repo_channels import _resolve_no_namespace
@@ -509,7 +628,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = []
+        mock_api.list_all_channels.return_value = _namespace_channels()
         mock_api.account.get.return_value = {}
 
         resolved = _resolve_namespace_and_channel(mock_api, "dev", require_namespace=False)
@@ -533,7 +652,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="other")]
+        mock_api.list_all_channels.return_value = _namespace_channels("other")
         resolved = classify_and_resolve(mock_api, "user1", owner_probe=lambda n: n == "user1")
         assert resolved.target == "org"
         assert resolved.owner == "user1"
@@ -562,7 +681,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myns")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myns")
         # Not a dotorg owner -> stays repo; bare name is a channel under the sole namespace.
         resolved = classify_and_resolve(mock_api, "dev", owner_probe=lambda n: False)
         assert resolved.target == "repo"
@@ -573,7 +692,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="user1")]
+        mock_api.list_all_channels.return_value = _namespace_channels("user1")
         with (
             patch("binstar_client.repocore.resolve.sys.stdin.isatty", return_value=True),
             patch("binstar_client.repocore.resolve.select_from_list", return_value="org"),
@@ -586,7 +705,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="user1")]
+        mock_api.list_all_channels.return_value = _namespace_channels("user1")
         with (
             patch("binstar_client.repocore.resolve.sys.stdin.isatty", return_value=True),
             patch("binstar_client.repocore.resolve.select_from_list", return_value="repo"),
@@ -597,11 +716,34 @@ class TestClassifyAndResolve:
         assert resolved.namespace == "user1"
         assert resolved.channel_name == "user1"
 
+    def test_bare_org_owner_colliding_with_subchannel_prompts(self):
+        """A bare name that is an org owner *and* an existing subchannel collides.
+
+        Even though it is not a top-level namespace, repocore would resolve it to
+        that subchannel directly, so the collision prompt must fire.
+        """
+        from binstar_client.repocore.resolve import classify_and_resolve
+
+        mock_api = MagicMock()
+        mock_api.list_all_channels.return_value = _readable_channels(
+            ("dude", None),
+            ("imhungry", "dude"),
+        )
+        with (
+            patch("binstar_client.repocore.resolve.sys.stdin.isatty", return_value=True),
+            patch("binstar_client.repocore.resolve.select_from_list", return_value="repo"),
+        ):
+            resolved = classify_and_resolve(mock_api, "imhungry", owner_probe=lambda n: True)
+        # Picking repo resolves to the existing subchannel unambiguously.
+        assert resolved.target == "repo"
+        assert resolved.namespace == "dude"
+        assert resolved.channel_name == "imhungry"
+
     def test_bare_ambiguous_non_tty_errors(self):
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="user1")]
+        mock_api.list_all_channels.return_value = _namespace_channels("user1")
         with patch("binstar_client.repocore.resolve.sys.stdin.isatty", return_value=False):
             with pytest.raises(typer.Exit):
                 classify_and_resolve(mock_api, "user1", owner_probe=lambda n: True)
@@ -737,7 +879,7 @@ class TestRepoCoreChannelsCLI:
         assert "dev" not in result.output
         aserver.list_channels.assert_not_called()
         # repocore namespaces must not be fetched for org-only listing
-        mock_api.list_user_organizations.assert_not_called()
+        mock_api.list_all_channels.assert_not_called()
 
     def test_channels_list_org_failure_isolated(self):
         runner = CliRunner()
@@ -804,7 +946,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = []
+        mock_api.list_all_channels.return_value = _namespace_channels()
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
         mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
             channel_path="testuser/newchannel", status_code=201
@@ -822,7 +964,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
         mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
             channel_path="myorg/dev", status_code=201
         )
@@ -889,7 +1031,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = []
+        mock_api.list_all_channels.return_value = _namespace_channels()
         type(mock_api).account = PropertyMock(side_effect=Exception("No account"))
         mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
             channel_path="newchannel", status_code=201
@@ -907,7 +1049,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = []
+        mock_api.list_all_channels.return_value = _namespace_channels()
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
         mock_api.create_namespace_channel.return_value = ChannelCreationResponse(
             channel_path="testuser/newchannel", status_code=201
@@ -925,7 +1067,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["remove", "dev"])
@@ -948,7 +1090,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = []
+        mock_api.list_all_channels.return_value = _namespace_channels()
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["remove", "dev"])
@@ -984,7 +1126,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["modify", "dev", "--privacy", "private"])
@@ -1008,6 +1150,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
+        mock_api.list_all_channels.return_value = _namespace_channels()
         mock_response = _mock_response(201, {"status": "uploaded"})
         mock_api.upload_file.return_value = mock_response
 
@@ -1064,7 +1207,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="jnguyenwoohoo")]
+        mock_api.list_all_channels.return_value = _namespace_channels("jnguyenwoohoo")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1091,7 +1234,7 @@ class TestRepoCoreChannelsCLI:
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
         mock_api.upload_file.return_value = _mock_response(201, {"status": "uploaded"})
         # "someowner" is not a repo namespace -> no repo/org collision, no prompt.
-        mock_api.list_user_organizations.return_value = [Namespace(name="myns")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myns")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1129,7 +1272,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myns")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myns")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1154,7 +1297,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myns")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myns")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1179,6 +1322,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
+        mock_api.list_all_channels.return_value = _namespace_channels()
         mock_response = _mock_response(201, {"status": "uploaded"})
         mock_api.upload_file.return_value = mock_response
 
@@ -1200,6 +1344,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
+        mock_api.list_all_channels.return_value = _namespace_channels()
         mock_response = _mock_response(200, {"status": "uploaded"})
         mock_api.upload_file.return_value = mock_response
 
@@ -1219,7 +1364,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
 
         with (
             _patch_repo_api(mock_api),
@@ -1237,7 +1382,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
 
         with (
             _patch_repo_api(mock_api),
@@ -1255,7 +1400,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
 
         with (
             _patch_repo_api(mock_api),
@@ -1272,7 +1417,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = Unauthorized()
 
         with (
@@ -1291,7 +1436,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = RepoCoreError("Upload failed")
 
         with (
@@ -1324,7 +1469,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = Unauthorized()
 
         with (
@@ -1343,7 +1488,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = RepoCoreError("Internal server error")
 
         with (
@@ -1377,7 +1522,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="testorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = RepoCoreError("Channel 'myorg/dev' not found")
 
         with (
@@ -1397,7 +1542,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev", "--unshare"])
@@ -1409,7 +1554,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev"])
@@ -1421,7 +1566,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev", "--role", "viewer"])
@@ -1436,7 +1581,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(
@@ -1452,10 +1597,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [
-            Namespace(name="org-a"),
-            Namespace(name="org-b"),
-        ]
+        mock_api.list_all_channels.return_value = _namespace_channels("org-a", "org-b")
 
         with (
             _patch_repo_api(mock_api),
@@ -1470,10 +1612,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_user_organizations.return_value = [
-            Namespace(name="org-a"),
-            Namespace(name="org-b"),
-        ]
+        mock_api.list_all_channels.return_value = _namespace_channels("org-a", "org-b")
 
         with (
             _patch_repo_api(mock_api),
@@ -1517,7 +1656,7 @@ class TestRepoCoreChannelsCLI:
         assert mock_api.share_channel.call_count == 2
         mock_api.share_channel.assert_any_call("myorg", "dev", "testuser", action="share", grant="read")
         mock_api.share_channel.assert_any_call("myorg", "staging", "testuser", action="share", grant="read")
-        mock_api.list_user_organizations.assert_not_called()
+        mock_api.list_all_channels.assert_not_called()
 
     def test_share_namespace_with_slash_format_throws_ambiguous(self):
         runner = CliRunner()
@@ -1534,7 +1673,7 @@ class TestRepoCoreChannelsCLI:
         mock_api.share_channel.assert_not_called()
 
 
-class TestRepoCoreViewAndRemove:
+class TestRepoCoreShowListingAndRemove:
     def _artifact(self, **kw):
         from binstar_client.repocore import Artifact
 
@@ -1545,15 +1684,41 @@ class TestRepoCoreViewAndRemove:
 
         return ArtifactFile(**kw)
 
-    def test_view_requires_channel(self):
+    def test_show_metadata_only_skips_listing(self):
+        """Bare `show` prints channel metadata and does no package paging."""
         runner = CliRunner()
         app = _get_channels_app()
-        with _patch_repo_api(MagicMock()):
-            result = runner.invoke(app, ["view", "--packages"])
-        assert result.exit_code == 1
-        assert "No channel specified" in result.output
+        mock_api = MagicMock()
 
-    def test_view_packages_summary(self):
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["show", "myns/dev"])
+
+        assert result.exit_code == 0, result.output
+        mock_api.get_namespace_channel.assert_called_once_with("myns/dev")
+        mock_api.list_artifacts.assert_not_called()
+
+    def test_show_routes_to_dotorg_for_owner(self):
+        """A bare name matching an anaconda.org owner delegates to the legacy show."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        with (
+            # owner_exists=True makes the owner probe report an anaconda.org owner,
+            # so classify_and_resolve routes the bare name to target="org".
+            _patch_repo_api(mock_api, owner_exists=True),
+            patch("binstar_client.commands.show.main") as mock_show_main,
+        ):
+            result = runner.invoke(app, ["show", "someowner"])
+
+        assert result.exit_code == 0, result.output
+        # Delegated to dotorg, not the repocore channel metadata call.
+        mock_api.get_namespace_channel.assert_not_called()
+        mock_show_main.assert_called_once()
+        spec = mock_show_main.call_args[0][0].spec
+        assert spec.user == "someowner"
+
+    def test_show_packages_summary(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
@@ -1563,25 +1728,13 @@ class TestRepoCoreViewAndRemove:
         )
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+            result = runner.invoke(app, ["show", "myns/dev", "--packages"])
 
         assert result.exit_code == 0, result.output
         assert "numpy" in result.output
         mock_api.list_artifacts.assert_called_with("myns/dev", offset=0, limit=100)
 
-    def test_view_defaults_to_packages(self):
-        runner = CliRunner()
-        app = _get_channels_app()
-        mock_api = MagicMock()
-        mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 1)
-
-        with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["view", "-c", "myns/dev"])
-
-        assert result.exit_code == 0, result.output
-        assert "numpy" in result.output
-
-    def test_view_files_shows_filenames(self):
+    def test_show_files_shows_filenames(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
@@ -1592,19 +1745,34 @@ class TestRepoCoreViewAndRemove:
         )
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["view", "-c", "myns/dev", "--files"])
+            result = runner.invoke(app, ["show", "myns/dev", "--files"])
 
         assert result.exit_code == 0, result.output
         assert "numpy-2.2.5-py313.conda" in result.output
 
-    def test_view_empty_channel(self):
+    def test_show_packages_and_files_are_mutually_exclusive(self):
+        """Passing both -p and --files is a user error, not a silent files-wins."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["show", "myns/dev", "-p", "--files"])
+
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output
+        # Rejected before any channel/listing work.
+        mock_api.get_namespace_channel.assert_not_called()
+        mock_api.list_artifacts.assert_not_called()
+
+    def test_show_empty_channel_listing(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_artifacts.return_value = ([], 0)
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+            result = runner.invoke(app, ["show", "myns/dev", "--packages"])
 
         assert result.exit_code == 0, result.output
         assert "No packages found" in result.output
@@ -1722,8 +1890,8 @@ class TestRepoCoreViewAndRemove:
         assert spec.version == "1.0"
         assert spec.basename == "mypkg-1.0.tar.bz2"
 
-    def test_view_pages_through_all_artifacts(self):
-        """view keeps requesting pages until the reported total is reached."""
+    def test_show_pages_through_all_artifacts(self):
+        """show --packages keeps requesting pages until the reported total is reached."""
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
@@ -1734,14 +1902,14 @@ class TestRepoCoreViewAndRemove:
         mock_api.list_artifacts.side_effect = [page1, page2, page3]
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+            result = runner.invoke(app, ["show", "myns/dev", "--packages"])
 
         assert result.exit_code == 0, result.output
         assert mock_api.list_artifacts.call_count == 3
         offsets = [call.kwargs["offset"] for call in mock_api.list_artifacts.call_args_list]
         assert offsets == [0, 100, 200]
 
-    def test_view_stops_on_short_page_despite_overreported_total(self):
+    def test_show_stops_on_short_page_despite_overreported_total(self):
         """A total larger than the data still terminates once a short page arrives."""
         runner = CliRunner()
         app = _get_channels_app()
@@ -1750,7 +1918,7 @@ class TestRepoCoreViewAndRemove:
         mock_api.list_artifacts.return_value = ([self._artifact(name="numpy", family="conda")], 999)
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["view", "-c", "myns/dev", "--packages"])
+            result = runner.invoke(app, ["show", "myns/dev", "--packages"])
 
         assert result.exit_code == 0, result.output
         # Short page (1 < _PAGE_SIZE) ends paging; no infinite loop.


### PR DESCRIPTION
Allows removing packages by filename with `anaconda channel remove-package -c chan PKG.xyz`

Allows viewing packages in a channel via `anaconda channel view`

Makes a refinement to the namespace resolver. It switches to using repocore subchannel fetching, so it is aware of shared namespaces, and can tell if a subchannel only exists in one namespace. This way, a user can reference a shared channel without necessarily needing to specify the namespace, as long as its unambiguous.