### PR TITLE
HUB-3479_notify_if_same_privacy_status

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -468,15 +468,32 @@ def modify_command(
     resolved = _resolve_namespace_and_channel(api, name, namespace)
     name = f"{resolved.namespace}/{resolved.channel_name}"
 
+    # The repo PUT endpoint is idempotent and reports whether it actually changed
+    # anything via the response status (201 = changed, 200 = value already set).
+    # We use that instead of pre-reading the channel, so a no-op is surfaced to the
+    # user rather than a misleading "Success!".
     if privacy:
-        api.update_channel(name, privacy=privacy)
-        state_map = {"private": "locked", "authenticated": "soft-locked", "public": "unlocked"}
-        console.print(f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[privacy]} ({privacy}).")
+        result = api.update_channel(name, privacy=privacy)
+        if result.changed:
+            state_map = {"private": "locked", "authenticated": "soft-locked", "public": "unlocked"}
+            console.print(
+                f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[privacy]} ({privacy})."
+            )
+        else:
+            console.print(f"[yellow]No change:[/yellow] Channel '[cyan]{name}[/cyan]' is already {privacy}.")
 
     if indexing_behavior:
-        api.update_channel(name, indexing_behavior=indexing_behavior)
-        state_map = {"frozen": "frozen", "default": "unfrozen"}
-        console.print(f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[indexing_behavior]}.")
+        result = api.update_channel(name, indexing_behavior=indexing_behavior)
+        if result.changed:
+            state_map = {"frozen": "frozen", "default": "unfrozen"}
+            console.print(
+                f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[indexing_behavior]}."
+            )
+        else:
+            console.print(
+                f"[yellow]No change:[/yellow] Channel '[cyan]{name}[/cyan]' indexing behavior is already "
+                f"{indexing_behavior}."
+            )
 
 
 def _do_upload(

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -468,10 +468,8 @@ def modify_command(
     resolved = _resolve_namespace_and_channel(api, name, namespace)
     name = f"{resolved.namespace}/{resolved.channel_name}"
 
-    # The repo PUT endpoint is idempotent and reports whether it actually changed
-    # anything via the response status (201 = changed, 200 = value already set).
-    # We use that instead of pre-reading the channel, so a no-op is surfaced to the
-    # user rather than a misleading "Success!".
+    # The PUT reports whether it actually changed anything, so a no-op is surfaced
+    # rather than a misleading "Success!".
     if privacy:
         result = api.update_channel(name, privacy=privacy)
         if result.changed:

--- a/binstar_client/repocore/__init__.py
+++ b/binstar_client/repocore/__init__.py
@@ -4,6 +4,7 @@ from binstar_client.repocore.client import REPO_API_PATH, AUTH_API_PATH, RepoCor
 from binstar_client.repocore.models import (
     Channel,
     ChannelCreationResponse,
+    ChannelUpdateResponse,
     Namespace,
     ResolvedChannel,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "RepoCoreClient",
     "Channel",
     "ChannelCreationResponse",
+    "ChannelUpdateResponse",
     "Namespace",
     "ResolvedChannel",
 ]

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -166,23 +166,12 @@ class RepoCoreClient(BaseClient):
         return Channel(**data)
 
     def update_channel(self, channel: str, **data) -> "ChannelUpdateResponse":
-        """Update a channel and report whether the request changed anything.
-
-        The repo endpoint is idempotent: it returns 201 when a submitted field
-        differed from the channel's current state and 200 when the channel already
-        held every submitted value. ``_manage_response`` is only used here to raise
-        on error statuses; the returned body is not needed, so both 200 and 201 are
-        treated as empty successes and the status is surfaced instead.
-        """
+        """Update a channel; ``changed`` reflects the endpoint's ``{"changed": bool}``
+        body (``false`` when the channel already held every submitted value)."""
         url = self._get_channel_url(channel)
         response = self.put(url, json=data)
-        self._manage_response(
-            response,
-            f"updating channel {channel}",
-            success_codes=[200, 201, 204],
-            empty_success_codes=[200, 201, 204],
-        )
-        return ChannelUpdateResponse(status_code=response.status_code)
+        body = self._manage_response(response, f"updating channel {channel}", success_codes=[200])
+        return ChannelUpdateResponse(changed=bool((body or {}).get("changed", False)))
 
     def list_all_channels(
         self, offset: int = 0, limit: int = 100, include_subchannels: bool = True

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -13,6 +13,7 @@ from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthori
 from binstar_client.repocore.models import (
     Channel,
     ChannelCreationResponse,
+    ChannelUpdateResponse,
     Namespace,
 )
 from binstar_client.repocore.package_utils import PackageType
@@ -164,12 +165,24 @@ class RepoCoreClient(BaseClient):
         data = self._manage_response(response, f"getting channel {channel}")
         return Channel(**data)
 
-    def update_channel(self, channel: str, **data):
+    def update_channel(self, channel: str, **data) -> "ChannelUpdateResponse":
+        """Update a channel and report whether the request changed anything.
+
+        The repo endpoint is idempotent: it returns 201 when a submitted field
+        differed from the channel's current state and 200 when the channel already
+        held every submitted value. ``_manage_response`` is only used here to raise
+        on error statuses; the returned body is not needed, so both 200 and 201 are
+        treated as empty successes and the status is surfaced instead.
+        """
         url = self._get_channel_url(channel)
         response = self.put(url, json=data)
-        return self._manage_response(
-            response, f"updating channel {channel}", success_codes=[200, 204], empty_success_codes=[200, 204]
+        self._manage_response(
+            response,
+            f"updating channel {channel}",
+            success_codes=[200, 201, 204],
+            empty_success_codes=[200, 201, 204],
         )
+        return ChannelUpdateResponse(status_code=response.status_code)
 
     def list_all_channels(
         self, offset: int = 0, limit: int = 100, include_subchannels: bool = True

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -74,6 +74,22 @@ class ChannelCreationResponse(BaseModel):
         return self.status_code == 201
 
 
+class ChannelUpdateResponse(BaseModel):
+    """Response from updating a channel.
+
+    The repo PUT endpoint is idempotent and signals whether the request actually
+    changed anything via the HTTP status: 201 when a submitted field differed from
+    the channel's current state, 200 when the channel already held every submitted
+    value (a no-op). Mirrors ``ChannelCreationResponse``.
+    """
+
+    status_code: int
+
+    @property
+    def changed(self) -> bool:
+        return self.status_code == 201
+
+
 class ResolvedChannel(BaseModel):
     """Resolved namespace and channel name.
 

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -75,19 +75,10 @@ class ChannelCreationResponse(BaseModel):
 
 
 class ChannelUpdateResponse(BaseModel):
-    """Response from updating a channel.
+    """Response from updating a channel. ``changed`` is ``false`` when the channel
+    already held every submitted value (a no-op)."""
 
-    The repo PUT endpoint is idempotent and signals whether the request actually
-    changed anything via the HTTP status: 201 when a submitted field differed from
-    the channel's current state, 200 when the channel already held every submitted
-    value (a no-op). Mirrors ``ChannelCreationResponse``.
-    """
-
-    status_code: int
-
-    @property
-    def changed(self) -> bool:
-        return self.status_code == 201
+    changed: bool = False
 
 
 class ResolvedChannel(BaseModel):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -254,8 +254,8 @@ class TestRepoCoreClientAPI:
 
     def test_update_channel(self):
         client = _make_client()
-        # 201 => the server applied a change.
-        client.put = MagicMock(return_value=_mock_response(201, None))
+        # 200 + {"changed": true} => the server applied a change.
+        client.put = MagicMock(return_value=_mock_response(200, {"changed": True}))
 
         result = client.update_channel("test", privacy="private")
         call_args = client.put.call_args
@@ -264,8 +264,8 @@ class TestRepoCoreClientAPI:
 
     def test_update_channel_no_op_returns_unchanged(self):
         client = _make_client()
-        # 200 => the channel already held the submitted value (idempotent no-op).
-        client.put = MagicMock(return_value=_mock_response(200, None))
+        # 200 + {"changed": false} => the channel already held the submitted value.
+        client.put = MagicMock(return_value=_mock_response(200, {"changed": False}))
 
         result = client.update_channel("test", privacy="private")
         assert result.changed is False
@@ -939,8 +939,8 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
-        # 201 => the PUT changed the channel.
-        mock_api.update_channel.return_value = ChannelUpdateResponse(status_code=201)
+        # changed => the PUT changed the channel.
+        mock_api.update_channel.return_value = ChannelUpdateResponse(changed=True)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["modify", "dev", "--privacy", "private"])
@@ -955,8 +955,8 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
-        # 200 => the channel already held the requested privacy.
-        mock_api.update_channel.return_value = ChannelUpdateResponse(status_code=200)
+        # not changed => the channel already held the requested privacy.
+        mock_api.update_channel.return_value = ChannelUpdateResponse(changed=False)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["modify", "dev", "--privacy", "public"])
@@ -973,7 +973,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
-        mock_api.update_channel.return_value = ChannelUpdateResponse(status_code=200)
+        mock_api.update_channel.return_value = ChannelUpdateResponse(changed=False)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["modify", "dev", "--indexing-behavior", "default"])

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 from binstar_client.repocore import (
     Channel,
     ChannelCreationResponse,
+    ChannelUpdateResponse,
     Namespace,
     RepoCoreClient,
     ResolvedChannel,
@@ -253,12 +254,21 @@ class TestRepoCoreClientAPI:
 
     def test_update_channel(self):
         client = _make_client()
-        mock_response = _mock_response(200, None)
-        client.put = MagicMock(return_value=mock_response)
+        # 201 => the server applied a change.
+        client.put = MagicMock(return_value=_mock_response(201, None))
 
-        client.update_channel("test", privacy="private")
+        result = client.update_channel("test", privacy="private")
         call_args = client.put.call_args
         assert call_args[1]["json"] == {"privacy": "private"}
+        assert result.changed is True
+
+    def test_update_channel_no_op_returns_unchanged(self):
+        client = _make_client()
+        # 200 => the channel already held the submitted value (idempotent no-op).
+        client.put = MagicMock(return_value=_mock_response(200, None))
+
+        result = client.update_channel("test", privacy="private")
+        assert result.changed is False
 
     def test_manage_response_401_raises_unauthorized(self):
         client = _make_client()
@@ -929,12 +939,49 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        # 201 => the PUT changed the channel.
+        mock_api.update_channel.return_value = ChannelUpdateResponse(status_code=201)
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["modify", "dev", "--privacy", "private"])
 
         assert result.exit_code == 0
+        assert "Success" in result.output
         mock_api.update_channel.assert_called_once_with("myorg/dev", privacy="private")
+
+    def test_channels_modify_privacy_no_change(self):
+        """A 200 (idempotent no-op) should warn instead of reporting success."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        # 200 => the channel already held the requested privacy.
+        mock_api.update_channel.return_value = ChannelUpdateResponse(status_code=200)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["modify", "dev", "--privacy", "public"])
+
+        assert result.exit_code == 0
+        assert "No change" in result.output
+        assert "already public" in result.output
+        assert "Success" not in result.output
+        mock_api.update_channel.assert_called_once_with("myorg/dev", privacy="public")
+
+    def test_channels_modify_indexing_no_change(self):
+        """A 200 (idempotent no-op) on indexing_behavior should warn, not succeed."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_user_organizations.return_value = [Namespace(name="myorg")]
+        mock_api.update_channel.return_value = ChannelUpdateResponse(status_code=200)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["modify", "dev", "--indexing-behavior", "default"])
+
+        assert result.exit_code == 0
+        assert "No change" in result.output
+        assert "Success" not in result.output
+        mock_api.update_channel.assert_called_once_with("myorg/dev", indexing_behavior="default")
 
     def test_channels_modify_no_options(self):
         runner = CliRunner()


### PR DESCRIPTION
Repocore is able to report when a channel actually got modified by returning a json indicating changed true. This updates the CLI to account for that.