### PR TITLE
HUB-3527_list_only_user_channels

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -52,12 +52,8 @@ _PAGE_SIZE = 100
 
 
 def _is_not_logged_in(exc: Exception) -> bool:
-    """True if ``exc`` means "no valid credentials for this backend".
-
-    Covers both backends' auth signals — repocore's ``Unauthorized`` /
-    ``LoginRequiredError`` and anaconda.org's ``Unauthorized`` (raised, e.g.,
-    when the token is missing). Used to stay quiet about a backend the user
-    simply isn't logged into when listing every source at once.
+    """True if ``exc`` is a not-logged-in signal from either backend — repocore's
+    ``Unauthorized`` / ``LoginRequiredError`` or anaconda.org's ``Unauthorized``.
     """
     return isinstance(exc, (Unauthorized, LoginRequiredError, dotorg_errors.Unauthorized))
 
@@ -271,11 +267,10 @@ def _upload_to_dotorg(
 
 
 def _iter_channels(api, include_all: bool):
-    """Yield the caller's channels, paging through the repocore channel listing.
+    """Yield the caller's channels, paging the repocore listing.
 
-    By default this pages ``GET /account/channels`` (the user's own channels plus
-    any shared with them). When ``include_all`` is set it pages ``GET /channels``
-    instead, which also includes public channels the user merely has read access to.
+    Default pages ``GET /account/channels`` (own + shared); ``include_all`` pages
+    ``GET /channels``, adding public channels the user only has read access to.
     """
     list_page = api.list_all_channels if include_all else api.list_my_channels
     offset = 0
@@ -383,22 +378,17 @@ def list_command(
     table.add_column("Artifacts", justify="right")
     table.add_column("Downloads", justify="right")
 
-    # When listing a single explicit source the user asked for exactly that, so
-    # any failure (including "not logged in") is worth reporting. When listing
-    # "all" we're speculatively querying both backends; most users are logged
-    # into only one, so an auth failure on the other is expected — stay quiet
-    # about it and only surface failures that look like a real outage.
+    # An explicit --source means the user asked for exactly that, so report any
+    # failure. "all" queries both backends, but most users are logged into only
+    # one — so a not-logged-in error on the other is expected and stays quiet.
     explicit_source = source != "all"
 
     notes: List[str] = []
     error_occurred = False
 
     def _note_failure(label: str, exc: Exception) -> None:
-        """Record a source failure, suppressing not-logged-in noise for ``all``.
-
-        Under ``--source all`` an auth error just means the user isn't logged
-        into that backend, which is the norm — stay quiet. A non-auth error
-        (network, 5xx) still surfaces since it signals a genuine problem.
+        """Record a source failure, but stay quiet about a backend the user just
+        isn't logged into under ``all``. Real outages (non-auth) still surface.
         """
         nonlocal error_occurred
         error_occurred = True

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -22,8 +22,9 @@ from binstar_client.commands import _channel_notices as channel_notices
 from binstar_client.commands import remove as remove_mod
 from binstar_client.commands import show as show_mod
 from binstar_client.commands import upload as upload_mod
+from binstar_client import errors as dotorg_errors
 from binstar_client.repocore import RepoCoreClient
-from binstar_client.repocore.errors import RepoCoreError, Unauthorized
+from binstar_client.repocore.errors import LoginRequiredError, RepoCoreError, Unauthorized
 from binstar_client.repocore.telemetry import ChannelEvents, UploadEvents
 from binstar_client.repocore.package_utils import PackageType, determine_package_type, windows_glob
 from binstar_client.repocore.resolve import (
@@ -48,6 +49,18 @@ configure_console_encoding()
 _NOT_APPLICABLE = "—"
 
 _PAGE_SIZE = 100
+
+
+def _is_not_logged_in(exc: Exception) -> bool:
+    """True if ``exc`` means "no valid credentials for this backend".
+
+    Covers both backends' auth signals — repocore's ``Unauthorized`` /
+    ``LoginRequiredError`` and anaconda.org's ``Unauthorized`` (raised, e.g.,
+    when the token is missing). Used to stay quiet about a backend the user
+    simply isn't logged into when listing every source at once.
+    """
+    return isinstance(exc, (Unauthorized, LoginRequiredError, dotorg_errors.Unauthorized))
+
 
 app = typer.Typer(
     name="channel",
@@ -257,11 +270,17 @@ def _upload_to_dotorg(
     upload_mod.main(args)
 
 
-def _iter_all_channels(api):
-    """Yield every channel the user can read, paging through ``GET /channels``."""
+def _iter_channels(api, include_all: bool):
+    """Yield the caller's channels, paging through the repocore channel listing.
+
+    By default this pages ``GET /account/channels`` (the user's own channels plus
+    any shared with them). When ``include_all`` is set it pages ``GET /channels``
+    instead, which also includes public channels the user merely has read access to.
+    """
+    list_page = api.list_all_channels if include_all else api.list_my_channels
     offset = 0
     while True:
-        channels, total, error = api.list_all_channels(offset=offset, limit=_PAGE_SIZE)
+        channels, total, error = list_page(offset=offset, limit=_PAGE_SIZE)
         if error:
             raise error
         yield from channels
@@ -270,11 +289,11 @@ def _iter_all_channels(api):
             break
 
 
-def _add_repo_rows(table: Table, api, namespace: Optional[str]) -> None:
+def _add_repo_rows(table: Table, api, namespace: Optional[str], include_all: bool) -> None:
     """Append anaconda.com (repocore) namespace/channel rows to the table."""
     namespaces: list[str] = []
     subchannels: dict[str, list] = {}
-    for channel in _iter_all_channels(api):
+    for channel in _iter_channels(api, include_all):
         if channel.parent is None:
             # A top-level channel is a namespace header, not a channel row.
             if channel.name not in namespaces:
@@ -339,8 +358,17 @@ def list_command(
         "--source",
         help="Which channels to list: 'repo' (anaconda.com), 'org' (anaconda.org owners), or 'all'.",
     ),
+    include_all: bool = typer.Option(
+        False,
+        "--all",
+        help="Include every anaconda.com channel you can read, not just your own and those shared with you.",
+    ),
 ) -> None:
-    """List all channels for the current user."""
+    """List channels for the current user.
+
+    By default only lists anaconda.com channels you own or that have been shared
+    with you. Pass --all to also include public channels you can read.
+    """
     if source not in ("all", "repo", "org"):
         console.print("[red]Error:[/red] --source must be one of: all, repo, org")
         raise typer.Exit(1)
@@ -355,15 +383,35 @@ def list_command(
     table.add_column("Artifacts", justify="right")
     table.add_column("Downloads", justify="right")
 
+    # When listing a single explicit source the user asked for exactly that, so
+    # any failure (including "not logged in") is worth reporting. When listing
+    # "all" we're speculatively querying both backends; most users are logged
+    # into only one, so an auth failure on the other is expected — stay quiet
+    # about it and only surface failures that look like a real outage.
+    explicit_source = source != "all"
+
     notes: List[str] = []
     error_occurred = False
 
+    def _note_failure(label: str, exc: Exception) -> None:
+        """Record a source failure, suppressing not-logged-in noise for ``all``.
+
+        Under ``--source all`` an auth error just means the user isn't logged
+        into that backend, which is the norm — stay quiet. A non-auth error
+        (network, 5xx) still surfaces since it signals a genuine problem.
+        """
+        nonlocal error_occurred
+        error_occurred = True
+        if not explicit_source and _is_not_logged_in(exc):
+            logger.debug("%s unavailable (not logged in), suppressed under --source all: %s", label, exc)
+            return
+        notes.append(f"{label} unavailable: {exc}")
+
     if source in ("all", "repo"):
         try:
-            _add_repo_rows(table, ctx.obj.repo_api, namespace)
+            _add_repo_rows(table, ctx.obj.repo_api, namespace, include_all)
         except Exception as exc:
-            notes.append(f"repo channels unavailable: {exc}")
-            error_occurred = True
+            _note_failure("repo channels", exc)
 
     if source in ("all", "org"):
         try:
@@ -371,8 +419,7 @@ def list_command(
             aserver_api = get_server_api(params.get("token"), params.get("site"))
             _add_org_rows(table, aserver_api)
         except Exception as exc:
-            notes.append(f"anaconda.org owners unavailable: {exc}")
-            error_occurred = True
+            _note_failure("anaconda.org owners", exc)
 
     channel_path = namespace if namespace else "all"
     ChannelEvents.accessed(

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -63,6 +63,10 @@ class RepoCoreClient(BaseClient):
         return join(self._api_base, "channels")
 
     @property
+    def _account_channels_url(self):
+        return join(self._api_base, "account", "channels")
+
+    @property
     def account(self):
         """Get user account information."""
         url = join(self._account_api_base, "account")
@@ -221,6 +225,32 @@ class RepoCoreClient(BaseClient):
             },
         )
         data, error = self._manage_response(response, "listing channels")
+        if error:
+            return [], 0, error
+        items = [Channel(**item) for item in (data or {}).get("items", [])]
+        return items, (data or {}).get("total_count", len(items)), None
+
+    def list_my_channels(
+        self, offset: int = 0, limit: int = 100, include_subchannels: bool = True
+    ) -> tuple[list[Channel], int, Optional[Exception]]:
+        """List only the channels the caller owns or has had shared with them.
+
+        Hits ``GET /account/channels`` — unlike ``list_all_channels`` this excludes
+        public channels the caller merely has read access to, returning just the
+        user's own namespaces plus channels explicitly shared with them.
+
+        Returns the page of channels, the server's total count (for paging), and
+        any error. On error the page is empty and the count is zero.
+        """
+        response = self.get(
+            self._account_channels_url,
+            params={
+                "offset": offset,
+                "limit": limit,
+                "include_subchannels": include_subchannels,
+            },
+        )
+        data, error = self._manage_response(response, "listing account channels")
         if error:
             return [], 0, error
         items = [Channel(**item) for item in (data or {}).get("items", [])]

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -65,9 +65,7 @@ def _iter_readable_channels(api):
     """
     offset = 0
     while True:
-        channels, total, error = api.list_my_channels(
-            offset=offset, limit=_CHANNEL_PAGE_SIZE, include_subchannels=True
-        )
+        channels, total, error = api.list_my_channels(offset=offset, limit=_CHANNEL_PAGE_SIZE, include_subchannels=True)
         if error:
             raise error
         yield from channels

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -54,16 +54,18 @@ _CHANNEL_PAGE_SIZE = 100
 
 
 def _iter_readable_channels(api):
-    """Yield every channel the caller can read (own + shared), paging ``GET /channels``.
+    """Yield the caller's own + shared channels, paging ``GET /account/channels``.
 
-    ``include_subchannels=True`` so the listing carries both top-level channels
-    (a namespace: ``parent is None``) and subchannels (an actual channel, whose
-    namespace is its ``parent``). The server scopes the result to the token's
-    permissions, so this spans the user's own channels plus any shared with it.
+    ``include_subchannels=True`` so the listing carries both namespaces
+    (``parent is None``) and subchannels (namespace is ``parent``).
+
+    Uses the account listing, not ``GET /channels``: resolution picks an upload
+    target, so it excludes public channels the user only reads. Not a write check
+    though — a read-only shared channel still appears and only 403s at upload.
     """
     offset = 0
     while True:
-        channels, total, error = api.list_all_channels(
+        channels, total, error = api.list_my_channels(
             offset=offset, limit=_CHANNEL_PAGE_SIZE, include_subchannels=True
         )
         if error:
@@ -143,8 +145,8 @@ def resolve_namespace_and_channel(
     if namespace:
         return _repo_channel(namespace=namespace, channel_name=name)
 
-    # List every channel the caller can read — its own *and* any shared with it —
-    # so both existing-channel matching and namespace resolution see shared items.
+    # Own + shared channels only, so name matching and namespace resolution stay
+    # scoped to the user's channels rather than every public channel it can read.
     channels = list(_iter_readable_channels(api))
 
     # First, does the bare name already name a subchannel? A subchannel is an

--- a/binstar_client/utils/console_utils.py
+++ b/binstar_client/utils/console_utils.py
@@ -2,11 +2,15 @@
 
 """Console/terminal helpers shared across CLI commands.
 
-Rich writes Unicode box-drawing borders straight to ``sys.stdout``. On Windows
-the standard streams often use a legacy code page (e.g. ``cp1252``) that can't
-represent them, so with the ``backslashreplace`` error handler they render as
-escaped ``\\uXXXX`` literals instead of characters like ``┏━┳``. Reconfiguring
-the streams to UTF-8 fixes this, matching macOS/Linux output.
+Rich writes Unicode box-drawing borders (``┏━┳┃``) straight to ``sys.stdout``.
+When Rich believes the stream is UTF-8 it emits those characters verbatim; if
+the stream then encodes with the ``backslashreplace`` error handler over a codec
+that can't represent them, each one lands as an escaped ``\\uXXXX`` literal
+instead of a border — the classic broken table seen on Windows consoles.
+
+We defend against that by pinning the standard streams to UTF-8 with the
+``replace`` error handler (a real char, never ``\\uXXXX``), matching the clean
+output macOS/Linux already produce.
 """
 
 from __future__ import annotations
@@ -20,35 +24,66 @@ _configured = False
 
 
 def configure_console_encoding() -> None:
-    """Reconfigure Windows stdout/stderr to UTF-8 so Rich borders render.
+    """Pin stdout/stderr to UTF-8 so Rich borders render as characters.
 
-    No-op off Windows and safe to call multiple times; runs its work at most once.
+    Safe to call multiple times; does its work at most once. Never raises — a
+    stream that can't be reconfigured is left as-is rather than taking down the
+    CLI.
     """
     global _configured
     if _configured:
         return
     _configured = True
 
-    if sys.platform != 'win32':
-        return
-
     for stream in (sys.stdout, sys.stderr):
-        _reconfigure_stream_to_utf8(stream)
+        _pin_stream_to_utf8(stream)
 
 
-def _reconfigure_stream_to_utf8(stream: object) -> None:
-    """Switch a single text stream to UTF-8, ignoring streams that can't.
+def _pin_stream_to_utf8(stream: object) -> None:
+    """Ensure a single text stream encodes as UTF-8 with a safe error handler.
 
-    A non-reconfigurable or detached stream must never take down the CLI, so
-    failures fall back to prior behavior rather than raising.
+    Prefers ``TextIOWrapper.reconfigure``; when that isn't available (older or
+    non-standard streams) rewraps the underlying binary buffer. Both paths use
+    ``errors='replace'`` so an unencodable char degrades to ``?`` rather than a
+    ``\\uXXXX`` literal. ``backslashreplace`` is treated as "needs fixing" even
+    when the encoding already reports UTF-8, since that handler is exactly what
+    produces the escaped-literal borders.
     """
     if not isinstance(stream, io.TextIOWrapper):
         return
 
-    if (getattr(stream, 'encoding', '') or '').lower().replace('-', '') == 'utf8':
+    encoding_ok = (getattr(stream, 'encoding', '') or '').lower().replace('-', '') == 'utf8'
+    errors_ok = getattr(stream, 'errors', '') not in ('backslashreplace', 'xmlcharrefreplace')
+    if encoding_ok and errors_ok:
         return
 
+    # Preferred path: reconfigure in place (Python 3.7+ standard streams).
+    reconfigure = getattr(stream, 'reconfigure', None)
+    if callable(reconfigure):
+        try:
+            reconfigure(encoding='utf-8', errors='replace')
+            return
+        except (ValueError, OSError):
+            pass
+
+    # Fallback: rewrap the raw buffer. Flush first so buffered bytes aren't lost,
+    # and keep line_buffering so interactive output still appears promptly.
+    buffer = getattr(stream, 'buffer', None)
+    if buffer is None:
+        return
     try:
-        stream.reconfigure(encoding='utf-8', errors='backslashreplace')
+        stream.flush()
+        wrapped = io.TextIOWrapper(
+            buffer,
+            encoding='utf-8',
+            errors='replace',
+            newline='',
+            line_buffering=getattr(stream, 'line_buffering', False),
+        )
     except (ValueError, OSError):
-        pass
+        return
+
+    if stream is sys.stdout:
+        sys.stdout = wrapped
+    elif stream is sys.stderr:
+        sys.stderr = wrapped

--- a/tests/test_console_utils.py
+++ b/tests/test_console_utils.py
@@ -8,6 +8,8 @@ import pytest
 
 import binstar_client.utils.console_utils as console_utils
 
+BOX = "┏━┳┓"
+
 
 @pytest.fixture(autouse=True)
 def _reset_configured_flag(monkeypatch):
@@ -15,26 +17,16 @@ def _reset_configured_flag(monkeypatch):
     monkeypatch.setattr(console_utils, "_configured", False)
 
 
-def _install_streams(monkeypatch, platform, encoding, cls=io.TextIOWrapper):
-    monkeypatch.setattr(console_utils.sys, "platform", platform)
-    stdout = cls(io.BytesIO(), encoding=encoding, errors="backslashreplace")
-    stderr = cls(io.BytesIO(), encoding=encoding, errors="backslashreplace")
+def _install_streams(monkeypatch, encoding, errors, cls=io.TextIOWrapper):
+    stdout = cls(io.BytesIO(), encoding=encoding, errors=errors)
+    stderr = cls(io.BytesIO(), encoding=encoding, errors=errors)
     monkeypatch.setattr(console_utils.sys, "stdout", stdout)
     monkeypatch.setattr(console_utils.sys, "stderr", stderr)
     return stdout, stderr
 
 
-def test_leaves_streams_alone_off_windows(monkeypatch):
-    stdout, stderr = _install_streams(monkeypatch, "linux", "cp1252")
-
-    console_utils.configure_console_encoding()
-
-    assert stdout.encoding == "cp1252"
-    assert stderr.encoding == "cp1252"
-
-
-def test_reconfigures_both_streams_on_windows(monkeypatch):
-    stdout, stderr = _install_streams(monkeypatch, "win32", "cp1252")
+def test_reconfigures_narrow_codec_to_utf8(monkeypatch):
+    stdout, stderr = _install_streams(monkeypatch, "cp1252", "backslashreplace")
 
     console_utils.configure_console_encoding()
 
@@ -42,23 +34,94 @@ def test_reconfigures_both_streams_on_windows(monkeypatch):
     assert stderr.encoding == "utf-8"
 
 
-def test_box_characters_round_trip_after_reconfigure(monkeypatch):
-    """The bug's payoff: box-drawing chars encode instead of becoming \\uXXXX."""
-    stdout, _ = _install_streams(monkeypatch, "win32", "cp1252")
+def test_fixes_backslashreplace_even_when_encoding_is_utf8(monkeypatch):
+    # The exact broken Windows state: encoding *reports* utf-8, but the
+    # backslashreplace handler still escapes box chars to \uXXXX literals.
+    stdout, stderr = _install_streams(monkeypatch, "utf-8", "backslashreplace")
 
     console_utils.configure_console_encoding()
-    stdout.write("┏━┳┓")
+
+    assert stdout.errors == "replace"
+    assert stderr.errors == "replace"
+
+
+def test_leaves_healthy_utf8_stream_untouched(monkeypatch):
+    stdout, _ = _install_streams(monkeypatch, "utf-8", "strict")
+
+    console_utils.configure_console_encoding()
+
+    # Already UTF-8 with a safe handler — no reconfigure, no rewrap.
+    assert stdout.encoding == "utf-8"
+    assert stdout.errors == "strict"
+
+
+def test_box_characters_encode_instead_of_becoming_uXXXX(monkeypatch):
+    """The bug's payoff: borders land as real bytes, never as \\uXXXX literals."""
+    stdout, _ = _install_streams(monkeypatch, "cp1252", "backslashreplace")
+
+    console_utils.configure_console_encoding()
+    stdout.write(BOX)
     stdout.flush()
 
-    assert stdout.buffer.getvalue().decode("utf-8") == "┏━┳┓"
+    written = stdout.buffer.getvalue()
+    assert written.decode("utf-8") == BOX
+    assert b"\\u" not in written
 
 
-def test_survives_non_reconfigurable_stream(monkeypatch):
+def test_fallback_rewraps_non_reconfigurable_stream(monkeypatch):
     class Stubborn(io.TextIOWrapper):
         def reconfigure(self, *args, **kwargs):
             raise OSError("cannot reconfigure")
 
-    _install_streams(monkeypatch, "win32", "cp1252", cls=Stubborn)
+    stdout, _ = _install_streams(monkeypatch, "cp1252", "backslashreplace", cls=Stubborn)
 
-    # A stream that refuses reconfiguration must not crash the CLI.
+    console_utils.configure_console_encoding()
+
+    # reconfigure() refused, so the raw buffer was rewrapped as a fresh UTF-8 stream.
+    assert console_utils.sys.stdout is not stdout
+    assert console_utils.sys.stdout.encoding == "utf-8"
+
+    console_utils.sys.stdout.write(BOX)
+    console_utils.sys.stdout.flush()
+    assert stdout.buffer.getvalue().decode("utf-8") == BOX
+
+
+def test_runs_at_most_once(monkeypatch):
+    stdout, _ = _install_streams(monkeypatch, "cp1252", "backslashreplace")
+    console_utils.configure_console_encoding()
+
+    # Swap in a fresh broken stream; a second call must be a no-op (guard set).
+    replacement, _ = _install_streams(monkeypatch, "cp1252", "backslashreplace")
+    console_utils.configure_console_encoding()
+
+    assert replacement.encoding == "cp1252"
+
+
+def test_ignores_non_textiowrapper_stream(monkeypatch):
+    class NotATextStream:
+        encoding = "cp1252"
+        errors = "backslashreplace"
+
+    stub = NotATextStream()
+    monkeypatch.setattr(console_utils.sys, "stdout", stub)
+    monkeypatch.setattr(console_utils.sys, "stderr", stub)
+
+    # Non-TextIOWrapper streams (redirected pipes, test doubles) are left as-is.
+    console_utils.configure_console_encoding()
+
+    assert console_utils.sys.stdout is stub
+
+
+def test_survives_stream_without_buffer(monkeypatch):
+    class NoBuffer(io.TextIOWrapper):
+        def reconfigure(self, *args, **kwargs):
+            raise OSError("cannot reconfigure")
+
+        @property
+        def buffer(self):
+            return None
+
+    _install_streams(monkeypatch, "cp1252", "backslashreplace", cls=NoBuffer)
+
+    # No reconfigure and no buffer to rewrap: must degrade quietly, not crash.
     console_utils.configure_console_encoding()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -230,6 +230,34 @@ class TestRepoCoreClientAPI:
         assert (items, total) == ([], 0)
         assert isinstance(error, Unauthorized)
 
+    def test_list_my_channels(self):
+        client = _make_client()
+        payload = {
+            "total_count": 2,
+            "items": [
+                {"name": "myorg", "privacy": "public"},
+                {"name": "dev", "privacy": "private", "parent": "myorg", "artifact_count": 3},
+            ],
+        }
+        client.get = MagicMock(return_value=_mock_response(200, payload))
+
+        items, total, error = client.list_my_channels()
+
+        assert error is None
+        assert total == 2
+        assert all(isinstance(ch, Channel) for ch in items)
+        # Hits /account/channels (own + shared only), with subchannels included.
+        call_url = client.get.call_args[0][0]
+        assert call_url.endswith("/api/repo/account/channels")
+        assert client.get.call_args[1]["params"]["include_subchannels"] is True
+        assert items[1].path == "myorg/dev"
+
+        # An error response yields an empty page rather than raising.
+        client.get = MagicMock(return_value=_mock_response(403, None))
+        items, total, error = client.list_my_channels()
+        assert (items, total) == ([], 0)
+        assert isinstance(error, Unauthorized)
+
     def test_create_channel(self):
         client = _make_client()
         mock_response = _mock_response(201, {"name": "new-channel"})
@@ -811,7 +839,8 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = (
+        # The default listing pages the caller's own + shared channels.
+        mock_api.list_my_channels.return_value = (
             [
                 Channel(name="main", privacy="public"),
                 Channel(
@@ -832,12 +861,38 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         assert "main" in result.output
         assert "dev" in result.output
+        # Default path hits /account/channels, not the broad /channels listing.
+        mock_api.list_my_channels.assert_called()
+        mock_api.list_all_channels.assert_not_called()
+
+    def test_channels_list_all_uses_broad_listing(self):
+        """`--all` pages GET /channels (every readable channel) instead of the
+        account listing."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_all_channels.return_value = (
+            [
+                Channel(name="main", privacy="public"),
+                Channel(name="public-only", privacy="public"),
+            ],
+            2,
+            None,
+        )
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["list", "--all"])
+
+        assert result.exit_code == 0
+        assert "public-only" in result.output
+        mock_api.list_all_channels.assert_called()
+        mock_api.list_my_channels.assert_not_called()
 
     def test_channels_list_with_namespace_filter(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = (
+        mock_api.list_my_channels.return_value = (
             [
                 Channel(name="org-a", privacy="public"),
                 Channel(name="org-b", privacy="public"),
@@ -865,7 +920,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = (
+        mock_api.list_my_channels.return_value = (
             [
                 Channel(name="myorg", privacy="public"),
                 Channel(name="dev", privacy="private", parent="myorg"),
@@ -889,7 +944,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = ([Channel(name="org-a", privacy="public")], 1, None)
+        mock_api.list_my_channels.return_value = ([Channel(name="org-a", privacy="public")], 1, None)
 
         with (
             _patch_repo_api(mock_api),
@@ -927,13 +982,14 @@ class TestRepoCoreChannelsCLI:
         assert "dev" not in result.output
         aserver.list_channels.assert_not_called()
         # repocore namespaces must not be fetched for org-only listing
+        mock_api.list_my_channels.assert_not_called()
         mock_api.list_all_channels.assert_not_called()
 
     def test_channels_list_org_failure_isolated(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = ([Channel(name="org-a", privacy="public")], 1, None)
+        mock_api.list_my_channels.return_value = ([Channel(name="org-a", privacy="public")], 1, None)
 
         aserver = MagicMock()
         aserver.user.side_effect = Exception("not logged in")
@@ -947,6 +1003,102 @@ class TestRepoCoreChannelsCLI:
         # repo section still renders; org failure is a dim note, not a crash
         assert result.exit_code == 0
         assert "org-a" in result.output
+        assert "unavailable" in result.output
+
+    def test_channels_list_all_suppresses_org_auth_failure(self):
+        """Logged into repo but not anaconda.org: `list` (default all) is quiet.
+
+        Most users are logged into only one backend; an auth failure on the other
+        under `--source all` is expected, so we don't nag with an 'unavailable'
+        note when the source the user *is* logged into worked.
+        """
+        from binstar_client import errors as dotorg_errors
+
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = ([Channel(name="org-a", privacy="public")], 1, None)
+
+        aserver = MagicMock()
+        aserver.user.side_effect = dotorg_errors.Unauthorized("Authentication token is missing.", 401)
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.get_server_api", return_value=aserver),
+        ):
+            result = runner.invoke(app, ["list"])
+
+        assert result.exit_code == 0
+        assert "org-a" in result.output
+        # Not-logged-into-dotorg is silent under the default all-sources listing.
+        assert "unavailable" not in result.output
+
+    def test_channels_list_all_suppresses_repo_auth_failure(self):
+        """Logged into anaconda.org but not repo: `list` (default all) is quiet."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.side_effect = Unauthorized("Please run `anaconda login`.")
+
+        aserver = MagicMock()
+        aserver.user.return_value = {"login": "user1"}
+        aserver.user_orgs.return_value = [{"login": "org1"}]
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.get_server_api", return_value=aserver),
+        ):
+            result = runner.invoke(app, ["list"])
+
+        assert result.exit_code == 0
+        # org section rendered; repo auth failure suppressed.
+        assert "user1" in result.output
+        assert "unavailable" not in result.output
+
+    def test_channels_list_explicit_source_reports_auth_failure(self):
+        """An auth failure on an *explicitly requested* source is still reported.
+
+        The user asked for exactly `--source org`, so "not logged in" is the
+        answer they need, not something to hide.
+        """
+        from binstar_client import errors as dotorg_errors
+
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+
+        aserver = MagicMock()
+        aserver.user.side_effect = dotorg_errors.Unauthorized("Authentication token is missing.", 401)
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.get_server_api", return_value=aserver),
+        ):
+            result = runner.invoke(app, ["list", "--source", "org"])
+
+        assert result.exit_code == 0
+        assert "unavailable" in result.output
+        # repo listing was never consulted for an org-only request.
+        mock_api.list_my_channels.assert_not_called()
+
+    def test_channels_list_all_reports_repo_non_auth_failure(self):
+        """A non-auth repo failure (real outage) still surfaces under all-sources."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.side_effect = RepoCoreError("Service Unavailable")
+
+        aserver = MagicMock()
+        aserver.user.return_value = {"login": "user1"}
+        aserver.user_orgs.return_value = []
+
+        with (
+            _patch_repo_api(mock_api),
+            patch("binstar_client.commands._repo_channels.get_server_api", return_value=aserver),
+        ):
+            result = runner.invoke(app, ["list"])
+
+        assert result.exit_code == 0
         assert "unavailable" in result.output
 
     def test_channels_list_invalid_source(self):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -22,16 +22,16 @@ from binstar_client.repocore.errors import (
 
 
 def _namespace_channels(*names):
-    """Build a ``list_all_channels`` return value from top-level channel names.
+    """Build a ``list_my_channels`` return value from top-level channel names.
 
-    The resolver derives namespaces from the top-level channels the user can
-    read; a single unpaged page is enough for tests.
+    The resolver derives namespaces from the caller's own + shared top-level
+    channels; a single unpaged page is enough for tests.
     """
     return ([Channel(name=n, privacy="private") for n in names], len(names), None)
 
 
 def _readable_channels(*channels):
-    """Build a ``list_all_channels`` return value from ``(name, parent)`` pairs.
+    """Build a ``list_my_channels`` return value from ``(name, parent)`` pairs.
 
     A ``parent`` of ``None`` is a top-level channel (a namespace); a non-None
     parent makes it a subchannel under that namespace.
@@ -500,7 +500,7 @@ class TestResolveNamespaceAndChannel:
         resolved = _resolve_namespace_and_channel(mock_api, "myorg/dev")
         assert resolved.namespace == "myorg"
         assert resolved.channel_name == "dev"
-        mock_api.list_all_channels.assert_not_called()
+        mock_api.list_my_channels.assert_not_called()
 
     def test_explicit_namespace_flag(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
@@ -509,7 +509,7 @@ class TestResolveNamespaceAndChannel:
         resolved = _resolve_namespace_and_channel(mock_api, "dev", namespace="myorg")
         assert resolved.namespace == "myorg"
         assert resolved.channel_name == "dev"
-        mock_api.list_all_channels.assert_not_called()
+        mock_api.list_my_channels.assert_not_called()
 
     def test_ambiguous_slash_and_flag_exits(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
@@ -523,7 +523,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         resolved = _resolve_namespace_and_channel(mock_api, "dev")
         assert resolved.namespace == "myorg"
         assert resolved.channel_name == "dev"
@@ -533,7 +533,7 @@ class TestResolveNamespaceAndChannel:
         import typer
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
         with pytest.raises(typer.Exit):
             _resolve_namespace_and_channel(mock_api, "dev")
 
@@ -541,7 +541,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("org-a", "org-b")
+        mock_api.list_my_channels.return_value = _namespace_channels("org-a", "org-b")
 
         with patch("binstar_client.repocore.resolve.select_from_list", return_value="org-b"):
             resolved = _resolve_namespace_and_channel(mock_api, "dev")
@@ -555,7 +555,7 @@ class TestResolveNamespaceAndChannel:
 
         mock_api = MagicMock()
         # A channel shared from an org the user is not a member of is still offered.
-        mock_api.list_all_channels.return_value = _namespace_channels("shared-org")
+        mock_api.list_my_channels.return_value = _namespace_channels("shared-org")
 
         resolved = _resolve_namespace_and_channel(mock_api, "dev")
 
@@ -564,7 +564,7 @@ class TestResolveNamespaceAndChannel:
         # Resolution uses the readable-channels listing (which includes subchannels
         # so an existing channel by that name can be matched directly), and never
         # the org-membership endpoint.
-        assert mock_api.list_all_channels.call_args.kwargs["include_subchannels"] is True
+        assert mock_api.list_my_channels.call_args.kwargs["include_subchannels"] is True
         mock_api.list_user_organizations.assert_not_called()
 
     def test_namespaces_paged_and_deduped(self):
@@ -575,14 +575,14 @@ class TestResolveNamespaceAndChannel:
         page1 = ([Channel(name=f"ns{i}", privacy="private") for i in range(100)], 150, None)
         # Second page repeats ns0 (dedup) and adds ns100 (the sole *new* namespace).
         page2 = ([Channel(name="ns0", privacy="private"), Channel(name="ns100", privacy="private")], 150, None)
-        mock_api.list_all_channels.side_effect = [page1, page2]
+        mock_api.list_my_channels.side_effect = [page1, page2]
 
         with patch("binstar_client.repocore.resolve.select_from_list", return_value="ns100") as sel:
             resolved = _resolve_namespace_and_channel(mock_api, "dev")
 
         assert resolved.namespace == "ns100"
         # Two pages fetched; the picker saw 101 distinct namespaces (ns0..ns100, no dup).
-        assert mock_api.list_all_channels.call_count == 2
+        assert mock_api.list_my_channels.call_count == 2
         assert len(sel.call_args[0][1]) == 101
 
     def test_existing_subchannel_resolves_directly(self):
@@ -594,7 +594,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _readable_channels(
+        mock_api.list_my_channels.return_value = _readable_channels(
             ("dude", None),
             ("fluffybunnies", None),
             ("imhungry", "dude"),
@@ -612,7 +612,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _readable_channels(
+        mock_api.list_my_channels.return_value = _readable_channels(
             ("dude", None),
             ("fluffybunnies", None),
             ("imhungry", "dude"),
@@ -635,7 +635,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _readable_channels(
+        mock_api.list_my_channels.return_value = _readable_channels(
             ("dude", None),
             ("fluffybunnies", None),
             ("imhungry", "dude"),
@@ -701,7 +701,7 @@ class TestResolveNamespaceAndChannel:
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
         mock_api.account.get.return_value = {}
 
         resolved = _resolve_namespace_and_channel(mock_api, "dev", require_namespace=False)
@@ -725,7 +725,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("other")
+        mock_api.list_my_channels.return_value = _namespace_channels("other")
         resolved = classify_and_resolve(mock_api, "user1", owner_probe=lambda n: n == "user1")
         assert resolved.target == "org"
         assert resolved.owner == "user1"
@@ -754,7 +754,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myns")
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
         # Not a dotorg owner -> stays repo; bare name is a channel under the sole namespace.
         resolved = classify_and_resolve(mock_api, "dev", owner_probe=lambda n: False)
         assert resolved.target == "repo"
@@ -765,7 +765,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("user1")
+        mock_api.list_my_channels.return_value = _namespace_channels("user1")
         with (
             patch("binstar_client.repocore.resolve.sys.stdin.isatty", return_value=True),
             patch("binstar_client.repocore.resolve.select_from_list", return_value="org"),
@@ -778,7 +778,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("user1")
+        mock_api.list_my_channels.return_value = _namespace_channels("user1")
         with (
             patch("binstar_client.repocore.resolve.sys.stdin.isatty", return_value=True),
             patch("binstar_client.repocore.resolve.select_from_list", return_value="repo"),
@@ -798,7 +798,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _readable_channels(
+        mock_api.list_my_channels.return_value = _readable_channels(
             ("dude", None),
             ("imhungry", "dude"),
         )
@@ -816,7 +816,7 @@ class TestClassifyAndResolve:
         from binstar_client.repocore.resolve import classify_and_resolve
 
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("user1")
+        mock_api.list_my_channels.return_value = _namespace_channels("user1")
         with patch("binstar_client.repocore.resolve.sys.stdin.isatty", return_value=False):
             with pytest.raises(typer.Exit):
                 classify_and_resolve(mock_api, "user1", owner_probe=lambda n: True)
@@ -1148,7 +1148,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="testuser/newchannel", status_code=201),
@@ -1167,7 +1167,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="myorg/dev", status_code=201),
             None,
@@ -1237,7 +1237,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
         type(mock_api).account = PropertyMock(side_effect=Exception("No account"))
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="newchannel", status_code=201),
@@ -1256,7 +1256,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
         type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="testuser/newchannel", status_code=201),
@@ -1275,7 +1275,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         mock_api.remove_channel.return_value = (None, None)
 
         with _patch_repo_api(mock_api):
@@ -1300,7 +1300,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["remove", "dev"])
@@ -1339,7 +1339,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         # changed => the PUT changed the channel.
         mock_api.update_channel.return_value = (ChannelUpdateResponse(changed=True), None)
 
@@ -1355,7 +1355,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         # not changed => the channel already held the requested privacy.
         mock_api.update_channel.return_value = (ChannelUpdateResponse(changed=False), None)
 
@@ -1373,7 +1373,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         mock_api.update_channel.return_value = (ChannelUpdateResponse(changed=False), None)
 
         with _patch_repo_api(mock_api):
@@ -1401,7 +1401,7 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.upload_file.return_value = ({"status": "uploaded"}, None)
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
 
         with (
             _patch_repo_api(mock_api),
@@ -1456,7 +1456,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("jnguyenwoohoo")
+        mock_api.list_my_channels.return_value = _namespace_channels("jnguyenwoohoo")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1483,7 +1483,7 @@ class TestRepoCoreChannelsCLI:
         mock_api.upload_file.return_value = ({"status": "uploaded"}, None)
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
         # "someowner" is not a repo namespace -> no repo/org collision, no prompt.
-        mock_api.list_all_channels.return_value = _namespace_channels("myns")
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1521,7 +1521,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myns")
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1546,7 +1546,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myns")
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
 
         with (
             _patch_repo_api(mock_api, owner_exists=True),
@@ -1572,7 +1572,7 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.upload_file.return_value = ({"status": "uploaded"}, None)
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
 
         with (
             _patch_repo_api(mock_api),
@@ -1593,7 +1593,7 @@ class TestRepoCoreChannelsCLI:
         mock_api = MagicMock()
         mock_api.upload_file.return_value = ({"status": "uploaded"}, None)
         type(mock_api).account = PropertyMock(return_value={"default_channel": "main"})
-        mock_api.list_all_channels.return_value = _namespace_channels()
+        mock_api.list_my_channels.return_value = _namespace_channels()
 
         with (
             _patch_repo_api(mock_api),
@@ -1611,7 +1611,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
 
         with (
             _patch_repo_api(mock_api),
@@ -1629,7 +1629,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
 
         with (
             _patch_repo_api(mock_api),
@@ -1647,7 +1647,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
 
         with (
             _patch_repo_api(mock_api),
@@ -1664,7 +1664,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = Unauthorized()
 
         with (
@@ -1684,7 +1684,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = RepoCoreError("Upload failed")
 
         with (
@@ -1717,7 +1717,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = Unauthorized()
 
         with (
@@ -1737,7 +1737,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = RepoCoreError("Internal server error")
 
         with (
@@ -1771,7 +1771,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("testorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("testorg")
         mock_api.upload_file.side_effect = RepoCoreError("Channel 'myorg/dev' not found")
 
         with (
@@ -1791,7 +1791,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         mock_api.share_channel.return_value = (None, None)
 
         with _patch_repo_api(mock_api):
@@ -1804,7 +1804,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         mock_api.share_channel.return_value = (None, None)
 
         with _patch_repo_api(mock_api):
@@ -1817,7 +1817,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         mock_api.share_channel.return_value = (None, None)
 
         with _patch_repo_api(mock_api):
@@ -1833,7 +1833,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("myorg")
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
         mock_api.share_channel.return_value = (None, None)
 
         with _patch_repo_api(mock_api):
@@ -1850,7 +1850,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("org-a", "org-b")
+        mock_api.list_my_channels.return_value = _namespace_channels("org-a", "org-b")
         mock_api.share_channel.return_value = (None, None)
 
         with (
@@ -1866,7 +1866,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_all_channels.return_value = _namespace_channels("org-a", "org-b")
+        mock_api.list_my_channels.return_value = _namespace_channels("org-a", "org-b")
         mock_api.share_channel.return_value = (None, None)
 
         with (
@@ -1912,7 +1912,7 @@ class TestRepoCoreChannelsCLI:
         assert mock_api.share_channel.call_count == 2
         mock_api.share_channel.assert_any_call("myorg", "dev", "testuser", action="share", grant="read")
         mock_api.share_channel.assert_any_call("myorg", "staging", "testuser", action="share", grant="read")
-        mock_api.list_all_channels.assert_not_called()
+        mock_api.list_my_channels.assert_not_called()
 
     def test_share_namespace_with_slash_format_throws_ambiguous(self):
         runner = CliRunner()

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1055,32 +1055,6 @@ class TestRepoCoreChannelsCLI:
         assert "user1" in result.output
         assert "unavailable" not in result.output
 
-    def test_channels_list_explicit_source_reports_auth_failure(self):
-        """An auth failure on an *explicitly requested* source is still reported.
-
-        The user asked for exactly `--source org`, so "not logged in" is the
-        answer they need, not something to hide.
-        """
-        from binstar_client import errors as dotorg_errors
-
-        runner = CliRunner()
-        app = _get_channels_app()
-        mock_api = MagicMock()
-
-        aserver = MagicMock()
-        aserver.user.side_effect = dotorg_errors.Unauthorized("Authentication token is missing.", 401)
-
-        with (
-            _patch_repo_api(mock_api),
-            patch("binstar_client.commands._repo_channels.get_server_api", return_value=aserver),
-        ):
-            result = runner.invoke(app, ["list", "--source", "org"])
-
-        assert result.exit_code == 0
-        assert "unavailable" in result.output
-        # repo listing was never consulted for an org-only request.
-        mock_api.list_my_channels.assert_not_called()
-
     def test_channels_list_all_reports_repo_non_auth_failure(self):
         """A non-auth repo failure (real outage) still surfaces under all-sources."""
         runner = CliRunner()


### PR DESCRIPTION
Repocore has two separate endpoints: one for all accessible channels and for just user channels. `channel list` will now use the user channel endpoint, but `--all` can be used for the broader endpoint.

Also incorporates the fix for HUB-3499, which is to suppress auth errors on `channel list` since users may not be logged into both dotcom and dotorg.

And attempts to fix the windows encoding issues again on channel list, while we're working in this area. (HUB-3498). It's getting a little wacky in that area, so I'm open to just using simpler box characters that don't need special sauce to display properly on Windows. I'm guessing the issue is related to what is noted here https://rich.readthedocs.io/en/stable/appendix/box.html