### PR TITLE
HUB-3501_show_channel_role_level

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -351,6 +351,8 @@ def _add_org_rows(table: Table, aserver_api, include_all: bool) -> None:
     table.add_row(*([_NOT_APPLICABLE] * cell_count))
 
     for owner in owners:
+        # Indent the owner in the first (Namespace / Channel) column, then fill
+        # every remaining column with a dash.
         table.add_row(f"  {owner}", *([_NOT_APPLICABLE] * (cell_count - 1)))
 
 
@@ -842,11 +844,17 @@ def share_command(
         "-n",
         help="Namespace for the channel (alternative to namespace/channel format)",
     ),
-    access: str = typer.Option(
-        "viewer",
+    access: Optional[str] = typer.Option(
+        None,
         "--access",
         "-r",
         help="Access level to grant: viewer (read) or collaborator (write). Defaults to viewer.",
+    ),
+    role: Optional[str] = typer.Option(
+        None,
+        "--role",
+        hidden=True,
+        help="Deprecated alias for --access.",
     ),
     unshare: bool = typer.Option(False, "--unshare", help="Unshare the channel instead of sharing"),
 ) -> None:
@@ -857,6 +865,10 @@ def share_command(
     if not channels:
         console.print("[red]Error:[/red] No channel specified. Use --channel option to specify channel(s) to share.")
         raise typer.Exit(1)
+
+    # --role was the original (already-released) flag name; accept it as a hidden
+    # alias for --access, preferring --access when both are given.
+    access = access or role or "viewer"
 
     if access not in ("viewer", "collaborator"):
         console.print("[red]Error:[/red] --access must be either 'viewer' or 'collaborator'.")

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -285,7 +285,13 @@ def _iter_channels(api, include_all: bool):
 
 
 def _add_repo_rows(table: Table, api, namespace: Optional[str], include_all: bool) -> None:
-    """Append anaconda.com (repocore) namespace/channel rows to the table."""
+    """Append anaconda.com (repocore) namespace/channel rows to the table.
+
+    The Access column only exists when ``include_all`` is False (see
+    ``list_command``): ``GET /channels`` doesn't report the caller's access
+    level, so under ``--all`` the column is dropped rather than filled with
+    dashes that would misleadingly read as "no access".
+    """
     namespaces: list[str] = []
     subchannels: dict[str, list] = {}
     for channel in _iter_channels(api, include_all):
@@ -303,27 +309,31 @@ def _add_repo_rows(table: Table, api, namespace: Optional[str], include_all: boo
         namespaces = [ns for ns in namespaces if ns == namespace]
 
     for ns in namespaces:
-        table.add_row(ns, "", "", "", "", "")
+        table.add_row(ns, "", "", "", "", *([] if include_all else [""]))
         for channel in subchannels.get(ns, []):
-            table.add_row(
+            row = [
                 f"  {channel.path}",
                 channel.privacy,
                 channel.description,
                 str(channel.artifact_count),
                 str(channel.download_count),
-                # /account/channels reports the caller's access level; --all
-                # (GET /channels) omits it, so fall back to a dash.
-                channel.access or _NOT_APPLICABLE,
-            )
+            ]
+            if not include_all:
+                # /account/channels reports the caller's access level.
+                row.append(channel.access or _NOT_APPLICABLE)
+            table.add_row(*row)
 
 
-def _add_org_rows(table: Table, aserver_api) -> None:
+def _add_org_rows(table: Table, aserver_api, include_all: bool) -> None:
     """Append anaconda.org owner rows to the table.
 
     anaconda.org owners are not repocore channels: they have no namespace and no
     channel-level privacy (both shown as a dash). Labels are intentionally *not*
     listed here — a label is not a channel, and `anaconda channel list` lists
     channels. Use ``anaconda label`` to work with labels.
+
+    Emits one fewer cell per row under ``include_all``, which drops the Access
+    column entirely (see ``list_command``).
     """
     login = aserver_api.user()["login"]
     owners = [login]
@@ -333,19 +343,15 @@ def _add_org_rows(table: Table, aserver_api) -> None:
         # Org membership lookup is best-effort; fall back to just the user.
         logger.debug("Could not list anaconda.org organizations, using user only: %s", exc)
 
+    # Access is the last column and only present when not --all.
+    cell_count = 5 if include_all else 6
+
     # Group header for the whole anaconda.org section: no namespace exists here,
     # so the Namespace / Channel column is a dash and owners are listed beneath it.
-    table.add_row(_NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE)
+    table.add_row(*([_NOT_APPLICABLE] * cell_count))
 
     for owner in owners:
-        table.add_row(
-            f"  {owner}",
-            _NOT_APPLICABLE,
-            _NOT_APPLICABLE,
-            _NOT_APPLICABLE,
-            _NOT_APPLICABLE,
-            _NOT_APPLICABLE,
-        )
+        table.add_row(f"  {owner}", *([_NOT_APPLICABLE] * (cell_count - 1)))
 
 
 @app.command(name="list", help="List all channels")
@@ -381,7 +387,11 @@ def list_command(
     table.add_column("Description")
     table.add_column("Artifacts", justify="right")
     table.add_column("Downloads", justify="right")
-    table.add_column("Access")
+    # --all lists channels via GET /channels, which doesn't report the caller's
+    # access level. Drop the column entirely rather than dashing it out — a dash
+    # would read as "no access" instead of "not reported".
+    if not include_all:
+        table.add_column("Access")
 
     # An explicit --source means the user asked for exactly that, so report any
     # failure. "all" queries both backends, but most users are logged into only
@@ -412,7 +422,7 @@ def list_command(
         try:
             params = getattr(ctx.obj, "params", {})
             aserver_api = get_server_api(params.get("token"), params.get("site"))
-            _add_org_rows(table, aserver_api)
+            _add_org_rows(table, aserver_api, include_all)
         except Exception as exc:
             _note_failure("anaconda.org owners", exc)
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -870,7 +870,7 @@ def share_command(
         result, error = api.share_channel(resolved.namespace, resolved.channel_name, user, action=action, grant=grant)
         event_kwargs = {"api": api, "app_name": app.info.name, "channel_path": ch, "user": user, "error": bool(error)}
         if action == "share":
-            ChannelEvents.share(**event_kwargs, role=access)
+            ChannelEvents.share(**event_kwargs, access=access)
         else:
             ChannelEvents.unshare(**event_kwargs)
         if error:

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -303,7 +303,7 @@ def _add_repo_rows(table: Table, api, namespace: Optional[str], include_all: boo
         namespaces = [ns for ns in namespaces if ns == namespace]
 
     for ns in namespaces:
-        table.add_row(ns, "", "", "", "")
+        table.add_row(ns, "", "", "", "", "")
         for channel in subchannels.get(ns, []):
             table.add_row(
                 f"  {channel.path}",
@@ -311,6 +311,9 @@ def _add_repo_rows(table: Table, api, namespace: Optional[str], include_all: boo
                 channel.description,
                 str(channel.artifact_count),
                 str(channel.download_count),
+                # /account/channels reports the caller's access level; --all
+                # (GET /channels) omits it, so fall back to a dash.
+                channel.access or _NOT_APPLICABLE,
             )
 
 
@@ -332,11 +335,12 @@ def _add_org_rows(table: Table, aserver_api) -> None:
 
     # Group header for the whole anaconda.org section: no namespace exists here,
     # so the Namespace / Channel column is a dash and owners are listed beneath it.
-    table.add_row(_NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE)
+    table.add_row(_NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE, _NOT_APPLICABLE)
 
     for owner in owners:
         table.add_row(
             f"  {owner}",
+            _NOT_APPLICABLE,
             _NOT_APPLICABLE,
             _NOT_APPLICABLE,
             _NOT_APPLICABLE,
@@ -377,6 +381,7 @@ def list_command(
     table.add_column("Description")
     table.add_column("Artifacts", justify="right")
     table.add_column("Downloads", justify="right")
+    table.add_column("Access")
 
     # An explicit --source means the user asked for exactly that, so report any
     # failure. "all" queries both backends, but most users are logged into only
@@ -827,11 +832,11 @@ def share_command(
         "-n",
         help="Namespace for the channel (alternative to namespace/channel format)",
     ),
-    role: str = typer.Option(
+    access: str = typer.Option(
         "viewer",
-        "--role",
+        "--access",
         "-r",
-        help="Role to grant: viewer (read) or collaborator (write). Defaults to viewer.",
+        help="Access level to grant: viewer (read) or collaborator (write). Defaults to viewer.",
     ),
     unshare: bool = typer.Option(False, "--unshare", help="Unshare the channel instead of sharing"),
 ) -> None:
@@ -843,11 +848,11 @@ def share_command(
         console.print("[red]Error:[/red] No channel specified. Use --channel option to specify channel(s) to share.")
         raise typer.Exit(1)
 
-    if role not in ("viewer", "collaborator"):
-        console.print("[red]Error:[/red] --role must be either 'viewer' or 'collaborator'.")
+    if access not in ("viewer", "collaborator"):
+        console.print("[red]Error:[/red] --access must be either 'viewer' or 'collaborator'.")
         raise typer.Exit(1)
 
-    grant = "write" if role == "collaborator" else "read"
+    grant = "write" if access == "collaborator" else "read"
 
     # Sharing is an anaconda.com (repo) concept only; resolve without an owner
     # probe so bare names stay repo channels rather than routing to anaconda.org.
@@ -865,7 +870,7 @@ def share_command(
         result, error = api.share_channel(resolved.namespace, resolved.channel_name, user, action=action, grant=grant)
         event_kwargs = {"api": api, "app_name": app.info.name, "channel_path": ch, "user": user, "error": bool(error)}
         if action == "share":
-            ChannelEvents.share(**event_kwargs, role=role)
+            ChannelEvents.share(**event_kwargs, role=access)
         else:
             ChannelEvents.unshare(**event_kwargs)
         if error:

--- a/binstar_client/repocore/models.py
+++ b/binstar_client/repocore/models.py
@@ -42,6 +42,9 @@ class Channel(BaseModel):
     updated: str = ""
     parent: Optional[str] = None
     owners: list[str] = Field(default_factory=list)
+    # The caller's access level on the channel (viewer/collaborator/owner). Only
+    # populated by GET /account/channels; the flat GET /channels listing omits it.
+    access: Optional[str] = None
 
     _handle_description = field_validator("description", mode="before")(_handle_none_as_empty_string)
 

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -52,31 +52,51 @@ def _org_channel(owner: str, channel_name: str) -> ResolvedChannel:
 
 _CHANNEL_PAGE_SIZE = 100
 
+# Access levels (from ``GET /account/channels``) that permit writing to a
+# channel — uploading, sharing, modifying. "viewer" is read-only and cannot be
+# an upload target, so it is filtered out of resolution.
+_WRITABLE_ACCESS = frozenset({"collaborator", "owner"})
 
-def _iter_readable_channels(api):
-    """Yield the caller's own + shared channels, paging ``GET /account/channels``.
+
+def _is_writable(channel) -> bool:
+    """Whether ``channel``'s access permits writing (upload/share/modify).
+
+    Resolution targets a channel the caller can write to, so read-only
+    ("viewer") channels are excluded. ``access`` is only populated when the
+    server reports it (SpiceDB enabled); when it is ``None`` we keep the channel
+    rather than filter it out, preserving the pre-access behavior where a
+    non-writable channel simply 403s at upload instead of vanishing here.
+    """
+    return channel.access is None or channel.access in _WRITABLE_ACCESS
+
+
+def _iter_writable_channels(api):
+    """Yield the caller's own + shared *writable* channels, paging ``GET /account/channels``.
 
     ``include_subchannels=True`` so the listing carries both namespaces
     (``parent is None``) and subchannels (namespace is ``parent``).
 
     Uses the account listing, not ``GET /channels``: resolution picks an upload
-    target, so it excludes public channels the user only reads. Not a write check
-    though — a read-only shared channel still appears and only 403s at upload.
+    target, so it excludes public channels the user only reads. Read-only
+    ("viewer") shared channels are also dropped via :func:`_is_writable`, so a
+    channel the caller cannot write to is never resolved as an upload/share/modify
+    target. When the server omits ``access`` (SpiceDB disabled), channels are
+    kept and a non-writable one 403s at upload as before.
     """
     offset = 0
     while True:
         channels, total, error = api.list_my_channels(offset=offset, limit=_CHANNEL_PAGE_SIZE, include_subchannels=True)
         if error:
             raise error
-        yield from channels
+        yield from (c for c in channels if _is_writable(c))
         offset += len(channels)
         # Stop on an empty/short page too, so an over-reported total can't loop forever.
         if not channels or len(channels) < _CHANNEL_PAGE_SIZE or offset >= total:
             break
 
 
-def _readable_namespaces(channels) -> List[str]:
-    """The distinct namespaces present in a readable-channel listing.
+def _writable_namespaces(channels) -> List[str]:
+    """The distinct namespaces present in a writable-channel listing.
 
     A top-level channel is itself a namespace; a subchannel's namespace is its
     ``parent``. Order is preserved and duplicates dropped so the picker is stable.
@@ -143,9 +163,10 @@ def resolve_namespace_and_channel(
     if namespace:
         return _repo_channel(namespace=namespace, channel_name=name)
 
-    # Own + shared channels only, so name matching and namespace resolution stay
-    # scoped to the user's channels rather than every public channel it can read.
-    channels = list(_iter_readable_channels(api))
+    # Own + shared writable channels only, so name matching and namespace
+    # resolution stay scoped to channels the user can actually write to rather
+    # than every public channel it can read (or a read-only shared channel).
+    channels = list(_iter_writable_channels(api))
 
     # First, does the bare name already name a subchannel? A subchannel is an
     # actual channel (has a parent namespace); a top-level channel is a namespace,
@@ -166,7 +187,7 @@ def resolve_namespace_and_channel(
 
     # No existing channel by that name — resolve the namespace it should live
     # under, so a brand-new channel name (e.g. `create`) still resolves.
-    namespaces = _readable_namespaces(channels)
+    namespaces = _writable_namespaces(channels)
 
     if not namespaces:
         if require_namespace:
@@ -239,12 +260,14 @@ def classify_and_resolve(
     repo_match = False
     if org_match:
         # Only fetch the (possibly expensive) channel listing to detect a real
-        # collision — where the bare name already *names* something on anaconda.com:
-        # a top-level namespace, or an existing readable subchannel by that name.
-        # The namespace *fallback* (placing a brand-new channel under some namespace)
-        # is not a collision: with no such name present, an org owner routes to org.
+        # collision — where the bare name already *names* something writable on
+        # anaconda.com: a top-level namespace, or an existing writable subchannel
+        # by that name. A read-only shared channel is not an upload target, so it
+        # is not a collision. The namespace *fallback* (placing a brand-new channel
+        # under some namespace) is not a collision either: with no such name
+        # present, an org owner routes to org.
         try:
-            channels = list(_iter_readable_channels(api))
+            channels = list(_iter_writable_channels(api))
             repo_match = any(c.name == name for c in channels)
         except Exception:
             repo_match = False

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -62,10 +62,13 @@ def _is_writable(channel) -> bool:
     """Whether ``channel``'s access permits writing (upload/share/modify).
 
     Resolution targets a channel the caller can write to, so read-only
-    ("viewer") channels are excluded. ``access`` is only populated when the
-    server reports it (SpiceDB enabled); when it is ``None`` we keep the channel
-    rather than filter it out, preserving the pre-access behavior where a
-    non-writable channel simply 403s at upload instead of vanishing here.
+    ("viewer") channels are excluded.
+
+    ``access`` is only populated when the server reports it (SpiceDB enabled).
+    When it is ``None`` — an older/other backend that does not report access at
+    all — we treat the channel as writable rather than filter it out, preserving
+    the pre-access behavior where a non-writable channel simply 403s at upload
+    instead of silently vanishing from resolution here.
     """
     return channel.access is None or channel.access in _WRITABLE_ACCESS
 

--- a/binstar_client/repocore/telemetry_models.py
+++ b/binstar_client/repocore/telemetry_models.py
@@ -111,7 +111,7 @@ class MemberInvitedEvent(TelemetryEvent):
     errorable: bool = True
     channel_path: str = Field(alias="channel.path")
     user: str
-    role: str
+    access: str
 
 
 class MemberRemovedEvent(TelemetryEvent):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -982,9 +982,10 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "public-only" in result.output
-        # --all uses GET /channels, which omits access; the Access column still renders
-        # (its header is present) but carries no access value for these channels.
-        assert "Access" in result.output
+        # --all uses GET /channels, which doesn't report the caller's access level,
+        # so the Access column is dropped entirely rather than shown with dashes
+        # (a dash would misleadingly read as "no access").
+        assert "Access" not in result.output
         mock_api.list_all_channels.assert_called()
         mock_api.list_my_channels.assert_not_called()
 

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -35,6 +35,9 @@ def _readable_channels(*channels):
 
     A ``parent`` of ``None`` is a top-level channel (a namespace); a non-None
     parent makes it a subchannel under that namespace.
+
+    Matches ``list_my_channels``'s ``(items, total_count, error)`` signature;
+    the trailing ``None`` is the error slot (no error).
     """
     items = [Channel(name=name, privacy="private", parent=parent) for name, parent in channels]
     return (items, len(items), None)
@@ -45,7 +48,7 @@ def _channels_with_access(*channels):
 
     Like :func:`_readable_channels` but stamps each channel's ``access`` level
     (``"viewer"``/``"collaborator"``/``"owner"``/``None``) so resolver tests can
-    exercise the writable filter.
+    exercise the writable filter. The trailing ``None`` is the error slot.
     """
     items = [Channel(name=name, privacy="private", parent=parent, access=access) for name, parent, access in channels]
     return (items, len(items), None)
@@ -1884,6 +1887,36 @@ class TestRepoCoreChannelsCLI:
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev"])
+
+        assert result.exit_code == 0
+        mock_api.share_channel.assert_called_once_with("myorg", "dev", "testuser", action="share", grant="read")
+
+    def test_share_role_is_hidden_alias_for_access(self):
+        # --role was the original released flag; it still maps to --access.
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
+        mock_api.share_channel.return_value = (None, None)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev", "--role", "collaborator"])
+
+        assert result.exit_code == 0
+        mock_api.share_channel.assert_called_once_with("myorg", "dev", "testuser", action="share", grant="write")
+
+    def test_share_access_wins_over_role(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
+        mock_api.share_channel.return_value = (None, None)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(
+                app,
+                ["share", "testuser", "--channel", "myorg/dev", "--access", "viewer", "--role", "collaborator"],
+            )
 
         assert result.exit_code == 0
         mock_api.share_channel.assert_called_once_with("myorg", "dev", "testuser", action="share", grant="read")

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -236,7 +236,13 @@ class TestRepoCoreClientAPI:
             "total_count": 2,
             "items": [
                 {"name": "myorg", "privacy": "public"},
-                {"name": "dev", "privacy": "private", "parent": "myorg", "artifact_count": 3},
+                {
+                    "name": "dev",
+                    "privacy": "private",
+                    "parent": "myorg",
+                    "artifact_count": 3,
+                    "access": "collaborator",
+                },
             ],
         }
         client.get = MagicMock(return_value=_mock_response(200, payload))
@@ -251,6 +257,9 @@ class TestRepoCoreClientAPI:
         assert call_url.endswith("/api/repo/account/channels")
         assert client.get.call_args[1]["params"]["include_subchannels"] is True
         assert items[1].path == "myorg/dev"
+        # /account/channels surfaces the caller's access level on each channel.
+        assert items[1].access == "collaborator"
+        assert items[0].access is None
 
         # An error response yields an empty page rather than raising.
         client.get = MagicMock(return_value=_mock_response(403, None))
@@ -849,6 +858,7 @@ class TestRepoCoreChannelsCLI:
                     parent="main",
                     artifact_count=10,
                     download_count=5,
+                    access="owner",
                 ),
             ],
             2,
@@ -861,6 +871,9 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         assert "main" in result.output
         assert "dev" in result.output
+        # The Access column surfaces the caller's access level from /account/channels.
+        assert "Access" in result.output
+        assert "owner" in result.output
         # Default path hits /account/channels, not the broad /channels listing.
         mock_api.list_my_channels.assert_called()
         mock_api.list_all_channels.assert_not_called()
@@ -885,6 +898,9 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "public-only" in result.output
+        # --all uses GET /channels, which omits access; the Access column still renders
+        # (its header is present) but carries no access value for these channels.
+        assert "Access" in result.output
         mock_api.list_all_channels.assert_called()
         mock_api.list_my_channels.assert_not_called()
 
@@ -1774,7 +1790,7 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 0
         mock_api.share_channel.assert_called_once_with("myorg", "dev", "testuser", action="unshare", grant="read")
 
-    def test_share_role_defaults_to_viewer(self):
+    def test_share_access_defaults_to_viewer(self):
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
@@ -1795,7 +1811,7 @@ class TestRepoCoreChannelsCLI:
         mock_api.share_channel.return_value = (None, None)
 
         with _patch_repo_api(mock_api):
-            result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev", "--role", "viewer"])
+            result = runner.invoke(app, ["share", "testuser", "--channel", "myorg/dev", "--access", "viewer"])
 
         assert result.exit_code == 0
         assert "Success" in result.output
@@ -1812,7 +1828,7 @@ class TestRepoCoreChannelsCLI:
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(
-                app, ["share", "testuser", "--channel", "myorg/dev", "--channel", "myorg/staging", "--role", "viewer"]
+                app, ["share", "testuser", "--channel", "myorg/dev", "--channel", "myorg/staging", "--access", "viewer"]
             )
 
         assert result.exit_code == 0
@@ -1831,7 +1847,7 @@ class TestRepoCoreChannelsCLI:
             _patch_repo_api(mock_api),
             patch("binstar_client.repocore.resolve.select_from_list", return_value="org-a"),
         ):
-            result = runner.invoke(app, ["share", "testuser", "--channel", "dev", "--role", "viewer"])
+            result = runner.invoke(app, ["share", "testuser", "--channel", "dev", "--access", "viewer"])
 
         assert result.exit_code == 0
         mock_api.share_channel.assert_called_once_with("org-a", "dev", "testuser", action="share", grant="read")
@@ -1851,7 +1867,7 @@ class TestRepoCoreChannelsCLI:
             ),
         ):
             result = runner.invoke(
-                app, ["share", "testuser", "--channel", "dev", "--channel", "staging", "--role", "viewer"]
+                app, ["share", "testuser", "--channel", "dev", "--channel", "staging", "--access", "viewer"]
             )
 
         assert result.exit_code == 0
@@ -1877,7 +1893,7 @@ class TestRepoCoreChannelsCLI:
                     "staging",
                     "--namespace",
                     "myorg",
-                    "--role",
+                    "--access",
                     "viewer",
                 ],
             )
@@ -1895,7 +1911,7 @@ class TestRepoCoreChannelsCLI:
 
         with _patch_repo_api(mock_api):
             result = runner.invoke(
-                app, ["share", "testuser", "--channel", "org-a/dev", "--namespace", "org-b", "--role", "viewer"]
+                app, ["share", "testuser", "--channel", "org-a/dev", "--namespace", "org-b", "--access", "viewer"]
             )
 
         assert result.exit_code == 1

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -40,6 +40,17 @@ def _readable_channels(*channels):
     return (items, len(items), None)
 
 
+def _channels_with_access(*channels):
+    """Build a ``list_my_channels`` return value from ``(name, parent, access)`` triples.
+
+    Like :func:`_readable_channels` but stamps each channel's ``access`` level
+    (``"viewer"``/``"collaborator"``/``"owner"``/``None``) so resolver tests can
+    exercise the writable filter.
+    """
+    items = [Channel(name=name, privacy="private", parent=parent, access=access) for name, parent, access in channels]
+    return (items, len(items), None)
+
+
 class TestPydanticModels:
     def test_namespace_model(self):
         ns = Namespace(name="test-org")
@@ -660,6 +671,79 @@ class TestResolveNamespaceAndChannel:
         assert resolved.channel_name == "brandnew"
         # No existing channel matched, so the picker offers namespaces to create under.
         assert set(sel.call_args[0][1]) == {"dude", "fluffybunnies"}
+
+    def test_viewer_access_channel_is_not_resolved(self):
+        """A read-only ("viewer") shared channel is filtered out of resolution.
+
+        ``imhungry`` exists only as a viewer channel, so the bare name does not
+        match a writable subchannel and instead falls through to namespace
+        resolution (which offers only the writable namespace ``dude``).
+        """
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _channels_with_access(
+            ("dude", None, "owner"),
+            ("imhungry", "fluffybunnies", "viewer"),
+        )
+
+        resolved = _resolve_namespace_and_channel(mock_api, "imhungry")
+
+        # Not resolved to the viewer subchannel; a single writable namespace
+        # remains, so "imhungry" resolves as a new channel under "dude".
+        assert resolved.namespace == "dude"
+        assert resolved.channel_name == "imhungry"
+
+    def test_writable_access_channels_are_resolved(self):
+        """Collaborator and owner channels stay resolvable as upload targets."""
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _channels_with_access(
+            ("dude", None, "owner"),
+            ("imhungry", "dude", "collaborator"),
+        )
+
+        with patch("binstar_client.repocore.resolve.select_from_list") as sel:
+            resolved = _resolve_namespace_and_channel(mock_api, "imhungry")
+
+        assert resolved.namespace == "dude"
+        assert resolved.channel_name == "imhungry"
+        sel.assert_not_called()
+
+    def test_viewer_namespace_excluded_from_picker(self):
+        """A namespace the caller only views is not offered when creating a channel."""
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _channels_with_access(
+            ("owned-ns", None, "owner"),
+            ("viewer-ns", None, "viewer"),
+        )
+
+        # Only one writable namespace remains, so a brand-new name resolves under
+        # it with no prompt — the viewer-only namespace is not a candidate.
+        resolved = _resolve_namespace_and_channel(mock_api, "brandnew")
+
+        assert resolved.namespace == "owned-ns"
+        assert resolved.channel_name == "brandnew"
+
+    def test_missing_access_is_kept(self):
+        """When the server omits ``access`` (SpiceDB off), channels are not filtered."""
+        from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
+
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _channels_with_access(
+            ("dude", None, None),
+            ("imhungry", "dude", None),
+        )
+
+        with patch("binstar_client.repocore.resolve.select_from_list") as sel:
+            resolved = _resolve_namespace_and_channel(mock_api, "imhungry")
+
+        assert resolved.namespace == "dude"
+        assert resolved.channel_name == "imhungry"
+        sel.assert_not_called()
 
     def test_no_namespaces_with_username_confirmed(self):
         from binstar_client.commands._repo_channels import _resolve_no_namespace

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -76,11 +76,11 @@ class TestPydanticTelemetryModels:
         assert event.package_name == "test-pkg"
 
     def test_member_invited_event_model(self):
-        event = MemberInvitedEvent(channel_path="myorg/dev", user="testuser", role="viewer")
+        event = MemberInvitedEvent(channel_path="myorg/dev", user="testuser", access="viewer")
         assert event.event_name == "member.invited"
         assert event.channel_path == "myorg/dev"
         assert event.user == "testuser"
-        assert event.role == "viewer"
+        assert event.access == "viewer"
 
     def test_member_removed_event_model(self):
         event = MemberRemovedEvent(channel_path="myorg/dev", user="testuser")


### PR DESCRIPTION
Updates CLI to show user channel access level (viewer, collaborator, owner) data from repocore API. This is only for user channels. If they use the --all flag, this access column is omitted since that displays non-user-specific channels.

View it using `anaconda channel list`

Updates resolver to exclude view-only channels from channel ops.

Renames role -> access throughout (including telemetry keys)