### PR TITLE
fix findings in HUB-3537

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -626,17 +626,22 @@ def modify_command(
     resolved = _resolve_namespace_and_channel(api, name, namespace)
     name = f"{resolved.namespace}/{resolved.channel_name}"
 
+    telemetry_kwargs = {"channel_path": name}
+    had_error = False
+
     # The PUT reports whether it actually changed anything, so a no-op is surfaced
     # rather than a misleading "Success!".
     if privacy:
         result, error = api.update_channel(name, privacy=privacy)
         if error:
+            had_error = True
             error_msg = str(error).lower()
             if "limit" in error_msg and "private" in error_msg:
                 limit_value = _extract_limit_from_error(error)
                 ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
-        ChannelEvents.modified(api, app.info.name, channel_path=name, privacy=privacy, error=bool(error))
+        telemetry_kwargs["privacy"] = privacy
         if error:
+            ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
             raise error
         if result.changed:
             state_map = {"private": "locked", "authenticated": "soft-locked", "public": "unlocked"}
@@ -648,10 +653,11 @@ def modify_command(
 
     if indexing_behavior:
         result, error = api.update_channel(name, indexing_behavior=indexing_behavior)
-        ChannelEvents.modified(
-            api, app.info.name, channel_path=name, indexing_behavior=indexing_behavior, error=bool(error)
-        )
         if error:
+            had_error = True
+        telemetry_kwargs["indexing_behavior"] = indexing_behavior
+        if error:
+            ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
             raise error
         if result.changed:
             state_map = {"frozen": "frozen", "default": "unfrozen"}
@@ -663,6 +669,9 @@ def modify_command(
                 f"[yellow]No change:[/yellow] Channel '[cyan]{name}[/cyan]' indexing behavior is already "
                 f"{indexing_behavior}."
             )
+
+    if not had_error:
+        ChannelEvents.modified(api, app.info.name, error=False, **telemetry_kwargs)
 
 
 def _do_upload(

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -626,52 +626,37 @@ def modify_command(
     resolved = _resolve_namespace_and_channel(api, name, namespace)
     name = f"{resolved.namespace}/{resolved.channel_name}"
 
-    telemetry_kwargs = {"channel_path": name}
-    had_error = False
-
-    # The PUT reports whether it actually changed anything, so a no-op is surfaced
-    # rather than a misleading "Success!".
+    update_data = {}
     if privacy:
-        result, error = api.update_channel(name, privacy=privacy)
-        if error:
-            had_error = True
-            error_msg = str(error).lower()
-            if "limit" in error_msg and "private" in error_msg:
-                limit_value = _extract_limit_from_error(error)
-                ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
-        telemetry_kwargs["privacy"] = privacy
-        if error:
-            ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
-            raise error
-        if result.changed:
-            state_map = {"private": "locked", "authenticated": "soft-locked", "public": "unlocked"}
-            console.print(
-                f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[privacy]} ({privacy})."
-            )
-        else:
-            console.print(f"[yellow]No change:[/yellow] Channel '[cyan]{name}[/cyan]' is already {privacy}.")
-
+        update_data["privacy"] = privacy
     if indexing_behavior:
-        result, error = api.update_channel(name, indexing_behavior=indexing_behavior)
-        if error:
-            had_error = True
-        telemetry_kwargs["indexing_behavior"] = indexing_behavior
-        if error:
-            ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
-            raise error
-        if result.changed:
-            state_map = {"frozen": "frozen", "default": "unfrozen"}
-            console.print(
-                f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' is now {state_map[indexing_behavior]}."
-            )
-        else:
-            console.print(
-                f"[yellow]No change:[/yellow] Channel '[cyan]{name}[/cyan]' indexing behavior is already "
-                f"{indexing_behavior}."
-            )
+        update_data["indexing_behavior"] = indexing_behavior
 
-    if not had_error:
-        ChannelEvents.modified(api, app.info.name, error=False, **telemetry_kwargs)
+    result, error = api.update_channel(name, **update_data)
+
+    telemetry_kwargs = {"channel_path": name, **update_data}
+
+    if error:
+        error_msg = str(error).lower()
+        if "limit" in error_msg and "private" in error_msg:
+            limit_value = _extract_limit_from_error(error)
+            ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
+        ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
+        raise error
+
+    ChannelEvents.modified(api, app.info.name, error=False, **telemetry_kwargs)
+
+    if result.changed:
+        messages = []
+        if privacy:
+            state_map = {"private": "locked", "authenticated": "soft-locked", "public": "unlocked"}
+            messages.append(f"privacy set to {state_map[privacy]} ({privacy})")
+        if indexing_behavior:
+            state_map = {"frozen": "frozen", "default": "unfrozen"}
+            messages.append(f"indexing behavior set to {state_map[indexing_behavior]}")
+        console.print(f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' {', '.join(messages)}.")
+    else:
+        console.print(f"[yellow]No change:[/yellow] Channel '[cyan]{name}[/cyan]' already has these settings.")
 
 
 def _do_upload(

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -102,6 +102,14 @@ def _extract_limit_from_error(error: Exception) -> Optional[int]:
     return int(limit_match.group(1)) if limit_match else None
 
 
+def _print_modify_result(result, channel_name: str, description: str) -> None:
+    """Print success or no-change message based on update result."""
+    if result.changed:
+        console.print(f"[green]Success![/green] Channel '[cyan]{channel_name}[/cyan]' is now {description}.")
+    else:
+        console.print(f"[yellow]No change:[/yellow] Channel '[cyan]{channel_name}[/cyan]' is already {description}.")
+
+
 @app.callback(invoke_without_command=True)
 def _callback(
     ctx: typer.Context,
@@ -626,37 +634,35 @@ def modify_command(
     resolved = _resolve_namespace_and_channel(api, name, namespace)
     name = f"{resolved.namespace}/{resolved.channel_name}"
 
-    update_data = {}
+    telemetry_kwargs = {"channel_path": name}
     if privacy:
-        update_data["privacy"] = privacy
+        telemetry_kwargs["privacy"] = privacy
     if indexing_behavior:
-        update_data["indexing_behavior"] = indexing_behavior
+        telemetry_kwargs["indexing_behavior"] = indexing_behavior
 
-    result, error = api.update_channel(name, **update_data)
+    if privacy:
+        result, error = api.update_channel(name, privacy=privacy)
+        if error:
+            error_msg = str(error).lower()
+            if "limit" in error_msg and "private" in error_msg:
+                limit_value = _extract_limit_from_error(error)
+                ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
+            ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
+            raise error
+        telemetry_kwargs["privacy_changed"] = result.changed
+        state_map = {"private": "locked", "authenticated": "soft-locked", "public": "unlocked"}
+        _print_modify_result(result, name, f"{state_map[privacy]} ({privacy})")
 
-    telemetry_kwargs = {"channel_path": name, **update_data}
-
-    if error:
-        error_msg = str(error).lower()
-        if "limit" in error_msg and "private" in error_msg:
-            limit_value = _extract_limit_from_error(error)
-            ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
-        ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
-        raise error
+    if indexing_behavior:
+        result, error = api.update_channel(name, indexing_behavior=indexing_behavior)
+        if error:
+            ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
+            raise error
+        telemetry_kwargs["indexing_behavior_changed"] = result.changed
+        state_map = {"frozen": "frozen", "default": "unfrozen"}
+        _print_modify_result(result, name, state_map[indexing_behavior])
 
     ChannelEvents.modified(api, app.info.name, error=False, **telemetry_kwargs)
-
-    if result.changed:
-        messages = []
-        if privacy:
-            state_map = {"private": "locked", "authenticated": "soft-locked", "public": "unlocked"}
-            messages.append(f"privacy set to {state_map[privacy]} ({privacy})")
-        if indexing_behavior:
-            state_map = {"frozen": "frozen", "default": "unfrozen"}
-            messages.append(f"indexing behavior set to {state_map[indexing_behavior]}")
-        console.print(f"[green]Success![/green] Channel '[cyan]{name}[/cyan]' {', '.join(messages)}.")
-    else:
-        console.print(f"[yellow]No change:[/yellow] Channel '[cyan]{name}[/cyan]' already has these settings.")
 
 
 def _do_upload(

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -117,7 +117,7 @@ class RepoCoreClient(BaseClient):
             pass
         return f"Error {action} (status {response.status_code})"
 
-    def _manage_response(self, response, action="", success_codes=[200], empty_success_codes=[204]):
+    def _manage_response(self, response, action="", success_codes=None, empty_success_codes=None):
         """Manages server responses
 
         Defaults to success_codes of only 200 and No Content success code of 204.
@@ -135,6 +135,11 @@ class RepoCoreClient(BaseClient):
                 - response_data: The response JSON or None
                 - error: Exception to raise if not None, None if successful
         """
+        if success_codes is None:
+            success_codes = [200]
+        if empty_success_codes is None:
+            empty_success_codes = [204]
+
         response_data = None
         try:
             response_data = response.json()
@@ -193,6 +198,8 @@ class RepoCoreClient(BaseClient):
         data, error = self._manage_response(response, f"getting channel {channel}")
         if error:
             return None, error
+        if not data:
+            return None, RepoCoreError("Server returned empty response")
         return Channel(**data), None
 
     def update_channel(self, channel: str, **data) -> tuple[Optional[ChannelUpdateResponse], Optional[Exception]]:
@@ -278,6 +285,8 @@ class RepoCoreClient(BaseClient):
         )
         if error:
             return None, error
+        if not result:
+            return None, RepoCoreError("Server returned empty response")
         return ChannelCreationResponse(status_code=response.status_code, **result), None
 
     def upload_file(self, filepath: str, channel: str, package_type: str):

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -25,7 +25,8 @@ class RepoCoreError(Exception):
 class Unauthorized(RepoCoreError):
     def __init__(self, message=None):
         base_msg = message or "The provided token does not allow you to perform this operation"
-        self.msg = base_msg + ". You may need to run 'anaconda login'"
+        base_msg += "."
+        self.msg = base_msg + " You may need to run 'anaconda login'"
         super().__init__(self.msg)
 
 

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -25,8 +25,8 @@ class RepoCoreError(Exception):
 class Unauthorized(RepoCoreError):
     def __init__(self, message=None):
         base_msg = message or "The provided token does not allow you to perform this operation"
-        base_msg += "."
-        self.msg = base_msg + " You may need to run 'anaconda login'"
+        separator = " " if base_msg.endswith(".") else ". "
+        self.msg = base_msg + separator + "You may need to run 'anaconda login'"
         super().__init__(self.msg)
 
 

--- a/binstar_client/repocore/telemetry.py
+++ b/binstar_client/repocore/telemetry.py
@@ -31,27 +31,41 @@ class Attributes:
         Args:
             client: RepoCoreClient or any BaseClient instance with account property
         """
+        self.user_id = None
+        self.user_email = None
+        self.organization_ids = []
+        self.account_tiers = []
 
         try:
             account = client.account
+        except Exception:
+            return
+
+        try:
             user = account.get("user", {})
-
             self.user_id = user.get("id")
-            user_email = user.get("email")
+        except Exception:
+            pass  # nosec B110
 
+        try:
+            user = account.get("user", {})
+            user_email = user.get("email")
             if user_email:
                 self.user_email = hashlib.sha256(user_email.encode()).hexdigest()
-            else:
-                self.user_email = None
+        except Exception:
+            pass  # nosec B110
 
+        try:
             subscriptions = account.get("subscriptions", [])
             self.organization_ids = [sub.get("org_id") or "" for sub in subscriptions]
+        except Exception:
+            pass  # nosec B110
+
+        try:
+            subscriptions = account.get("subscriptions", [])
             self.account_tiers = [sub.get("product_code") or "" for sub in subscriptions]
         except Exception:
-            self.user_id = None
-            self.user_email = None
-            self.organization_ids = []
-            self.account_tiers = []
+            pass  # nosec B110
 
     def to_dict(self) -> dict:
         """Export user attributes as a dictionary for telemetry.
@@ -69,7 +83,7 @@ class Attributes:
 
 def _check_error(event: TelemetryEvent, error: bool) -> None:
     """Append .error suffix to event name if error flag is set and event is errorable."""
-    if error and event.errorable:
+    if error and event.errorable and not event.event_name.endswith('.error'):
         event.event_name += '.error'
 
 
@@ -82,12 +96,15 @@ def _check_account_attrs(api) -> Attributes:
 
 def _count(event: TelemetryEvent, api, app_name: str | None, error: bool = False) -> None:
     """Helper to track telemetry events with user attributes."""
-    _check_error(event, error)
-    user_attrs = _check_account_attrs(api)
-    all_attributes = {**user_attrs.to_dict(), **event.attribute_dump()}
-    if app_name is None:
-        app_name = ""
-    _base_count(event.event_name, app_name, attributes=all_attributes)
+    try:
+        _check_error(event, error)
+        user_attrs = _check_account_attrs(api)
+        all_attributes = {**user_attrs.to_dict(), **event.attribute_dump()}
+        if app_name is None:
+            app_name = ""
+        _base_count(event.event_name, app_name, attributes=all_attributes)
+    except Exception:
+        pass  # nosec B110
 
 
 class ChannelEvents:

--- a/binstar_client/repocore/telemetry_models.py
+++ b/binstar_client/repocore/telemetry_models.py
@@ -71,6 +71,8 @@ class ChannelModifiedEvent(TelemetryEvent):
     channel_path: str = Field(alias="channel.path")
     privacy: Optional[str] = None
     indexing_behavior: Optional[str] = None
+    privacy_changed: Optional[bool] = Field(default=None, alias="privacy.changed")
+    indexing_behavior_changed: Optional[bool] = Field(default=None, alias="indexing_behavior.changed")
 
 
 class UpgradePromptImpressedEvent(TelemetryEvent):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1338,7 +1338,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "No change" in result.output
-        assert "already public" in result.output
+        assert "already unlocked (public)" in result.output
         assert "Success" not in result.output
         mock_api.update_channel.assert_called_once_with("myorg/dev", privacy="public")
 
@@ -1355,6 +1355,7 @@ class TestRepoCoreChannelsCLI:
 
         assert result.exit_code == 0
         assert "No change" in result.output
+        assert "already unfrozen" in result.output
         assert "Success" not in result.output
         mock_api.update_channel.assert_called_once_with("myorg/dev", indexing_behavior="default")
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
-from binstar_client.repocore.telemetry import Attributes, ChannelEvents, UpgradeEvents, UploadEvents
+from binstar_client.repocore.telemetry import Attributes, ChannelEvents, UpgradeEvents, UploadEvents, _check_error
 from binstar_client.repocore.telemetry_models import (
     ChannelAccessedEvent,
     ChannelCreatedEvent,
@@ -127,3 +127,36 @@ class TestAttributes:
         assert result["user_email"] is not None
         assert result["organization.ids"] == ["org1"]
         assert result["account.tier"] == ["pro"]
+
+    def test_attributes_partial_success_on_exception(self):
+        mock_client = MagicMock()
+        mock_user = {"id": "user456"}
+        mock_client.account = {
+            "user": mock_user,
+            "subscriptions": [{"org_id": "org3", "product_code": "enterprise"}],
+        }
+
+        def email_side_effect(key, default=None):
+            if key == "email":
+                raise Exception("Email fetch failed")
+            return mock_user.get(key, default)
+
+        mock_user_obj = MagicMock()
+        mock_user_obj.get = MagicMock(side_effect=email_side_effect)
+        mock_client.account["user"] = mock_user_obj
+
+        attrs = Attributes(mock_client)
+        assert attrs.user_id == "user456"
+        assert attrs.user_email is None
+        assert attrs.organization_ids == ["org3"]
+        assert attrs.account_tiers == ["enterprise"]
+
+
+class TestErrorSuffixIdempotence:
+    def test_error_suffix_is_idempotent(self):
+        event = ChannelCreatedEvent(channel_path="test/channel", privacy="private")
+        assert event.event_name == "channel.created"
+        _check_error(event, error=True)
+        assert event.event_name == "channel.created.error"
+        _check_error(event, error=True)
+        assert event.event_name == "channel.created.error"


### PR DESCRIPTION
Various fixes from QA testing:
- one call instead of two for channel modify with multiple arguments
- better Unauthorized error messages
- better error handling in `_count`
- partial account attributes recovery in event of errors with one attributes