### PR TITLE
HUB-3546: Add upgrade prompt for users hitting private channel limit

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -103,21 +103,25 @@ def _extract_limit_from_error(error: Exception) -> Optional[int]:
     return int(limit_match.group(1)) if limit_match else None
 
 
-def _prompt_upgrade(api, app_name: Optional[str], limit: Optional[int]) -> None:
-    """Prompt user to upgrade when they hit the private channel limit."""
+def _prompt_upgrade(api, app_name: Optional[str], limit: Optional[int], action: str) -> None:
+    """Prompt user to upgrade when they hit a limit."""
     limit_text = f" of {limit}" if limit else ""
-    console.print(f"\n[yellow]You have reached the limit{limit_text} for private channels.[/yellow]")
-    console.print("Upgrade your plan to create more private channels.")
+    if action == "share":
+        console.print(f"\n[yellow]You have reached the limit{limit_text} for collaborators.[/yellow]")
+        console.print("Upgrade your plan to add more collaborators.")
+    else:
+        console.print(f"\n[yellow]You have reached the limit{limit_text} for private channels.[/yellow]")
+        console.print("Upgrade your plan to create more private channels.")
 
-    UpgradeEvents.impressed(api, app_name)
+    UpgradeEvents.impressed(api, app_name, action)
 
     if typer.confirm("\nWould you like to view upgrade options?", default=True):
-        UpgradeEvents.accepted(api, app_name)
+        UpgradeEvents.accepted(api, app_name, action)
         upgrade_url = "https://anaconda.com/pricing"
         console.print(f"Opening [cyan]{upgrade_url}[/cyan] in your browser...")
         webbrowser.open(upgrade_url)
     else:
-        UpgradeEvents.dismissed(api, app_name)
+        UpgradeEvents.dismissed(api, app_name, action)
 
 
 def _print_modify_result(result, channel_name: str, description: str) -> None:
@@ -514,7 +518,7 @@ def create_command(
         if "limit" in error_msg and "private" in error_msg:
             limit_value = _extract_limit_from_error(error)
             ChannelEvents.limit(api, app.info.name, channel_path=channel_path, action="create", limit=limit_value)
-            _prompt_upgrade(api, app.info.name, limit_value)
+            _prompt_upgrade(api, app.info.name, limit_value, "create")
         ChannelEvents.created(**event_kwargs)
         raise error
     if response.created:
@@ -683,7 +687,7 @@ def modify_command(
             if "limit" in error_msg and "private" in error_msg:
                 limit_value = _extract_limit_from_error(error)
                 ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
-                _prompt_upgrade(api, app.info.name, limit_value)
+                _prompt_upgrade(api, app.info.name, limit_value, "modify")
             ChannelEvents.modified(api, app.info.name, error=True, **telemetry_kwargs)
             raise error
         telemetry_kwargs["privacy_changed"] = result.changed
@@ -916,6 +920,10 @@ def share_command(
         else:
             ChannelEvents.unshare(**event_kwargs)
         if error:
+            error_msg = str(error).lower()
+            if "maximum number of collaborators" in error_msg:
+                ChannelEvents.collaborator_limit(api, app.info.name, channel_path=ch, action="share")
+                _prompt_upgrade(api, app.info.name, None, "share")
             raise error
         console.print(f"[green]Success![/green] {action.capitalize()}d channel '[cyan]{ch}[/cyan]' with {user}")
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -25,7 +25,7 @@ from binstar_client.commands import show as show_mod
 from binstar_client.commands import upload as upload_mod
 from binstar_client import errors as dotorg_errors
 from binstar_client.repocore import RepoCoreClient
-from binstar_client.repocore.errors import LoginRequiredError, RepoCoreError, Unauthorized
+from binstar_client.repocore.errors import LoginRequiredError, RepoCoreError, Unauthenticated, Unauthorized
 from binstar_client.repocore.telemetry import ChannelEvents, UploadEvents, UpgradeEvents
 from binstar_client.repocore.package_utils import PackageType, determine_package_type, windows_glob
 from binstar_client.repocore.resolve import (
@@ -54,9 +54,9 @@ _PAGE_SIZE = 100
 
 def _is_not_logged_in(exc: Exception) -> bool:
     """True if ``exc`` is a not-logged-in signal from either backend — repocore's
-    ``Unauthorized`` / ``LoginRequiredError`` or anaconda.org's ``Unauthorized``.
+    ``Unauthenticated`` / ``LoginRequiredError`` or anaconda.org's ``Unauthorized``.
     """
-    return isinstance(exc, (Unauthorized, LoginRequiredError, dotorg_errors.Unauthorized))
+    return isinstance(exc, (Unauthenticated, LoginRequiredError, dotorg_errors.Unauthorized))
 
 
 app = typer.Typer(

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import webbrowser
+from enum import Enum
 from glob import glob
 from typing import List, Optional, Tuple, cast
 
@@ -97,9 +98,27 @@ class _DotOrgCredentials(BaseModel):
             return False
 
 
-def _extract_limit_from_error(error: Exception) -> Optional[int]:
-    """Extract channel limit number from error message."""
-    limit_match = re.search(r'has reached the limit of (\d+)', str(error))
+class LimitAction(str, Enum):
+    """Actions that can trigger limit errors."""
+
+    CREATE = "create"
+    SHARE = "share"
+
+
+def _extract_limit_from_error(error: Exception, action: LimitAction = LimitAction.CREATE) -> Optional[int]:
+    """Extract limit number from error message.
+
+    Args:
+        error: The error exception containing the limit message
+        action: The action being performed (CREATE or SHARE)
+
+    Returns:
+        The limit value if found, otherwise None
+    """
+    if action == LimitAction.CREATE:
+        limit_match = re.search(r'has reached the limit of (\d+)', str(error))
+    else:
+        limit_match = re.search(r'can only have (\d+)', str(error))
     return int(limit_match.group(1)) if limit_match else None
 
 
@@ -921,9 +940,10 @@ def share_command(
             ChannelEvents.unshare(**event_kwargs)
         if error:
             error_msg = str(error).lower()
-            if "maximum number of collaborators" in error_msg:
-                ChannelEvents.collaborator_limit(api, app.info.name, channel_path=ch, action="share")
-                _prompt_upgrade(api, app.info.name, None, "share")
+            if "collaborators" in error_msg and "can only have" in error_msg:
+                limit_value = _extract_limit_from_error(error, LimitAction.SHARE)
+                ChannelEvents.collaborator_limit(api, app.info.name, channel_path=ch, action="share", limit=limit_value)
+                _prompt_upgrade(api, app.info.name, limit_value, "share")
             raise error
         console.print(f"[green]Success![/green] {action.capitalize()}d channel '[cyan]{ch}[/cyan]' with {user}")
 

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -103,7 +103,7 @@ def _extract_limit_from_error(error: Exception) -> Optional[int]:
     return int(limit_match.group(1)) if limit_match else None
 
 
-def _prompt_upgrade(api, app_name: str, limit: Optional[int]) -> None:
+def _prompt_upgrade(api, app_name: Optional[str], limit: Optional[int]) -> None:
     """Prompt user to upgrade when they hit the private channel limit."""
     limit_text = f" of {limit}" if limit else ""
     console.print(f"\n[yellow]You have reached the limit{limit_text} for private channels.[/yellow]")

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -26,7 +26,7 @@ from binstar_client.commands import upload as upload_mod
 from binstar_client import errors as dotorg_errors
 from binstar_client.repocore import RepoCoreClient
 from binstar_client.repocore.errors import LoginRequiredError, RepoCoreError, Unauthorized
-from binstar_client.repocore.telemetry import ChannelEvents, UploadEvents
+from binstar_client.repocore.telemetry import ChannelEvents, UploadEvents, UpgradeEvents
 from binstar_client.repocore.package_utils import PackageType, determine_package_type, windows_glob
 from binstar_client.repocore.resolve import (
     classify_and_resolve,
@@ -103,16 +103,21 @@ def _extract_limit_from_error(error: Exception) -> Optional[int]:
     return int(limit_match.group(1)) if limit_match else None
 
 
-def prompt_upgrade(limit: Optional[int]) -> None:
+def _prompt_upgrade(api, app_name: str, limit: Optional[int]) -> None:
     """Prompt user to upgrade when they hit the private channel limit."""
     limit_text = f" of {limit}" if limit else ""
     console.print(f"\n[yellow]You have reached the limit{limit_text} for private channels.[/yellow]")
     console.print("Upgrade your plan to create more private channels.")
 
+    UpgradeEvents.impressed(api, app_name)
+
     if typer.confirm("\nWould you like to view upgrade options?", default=True):
+        UpgradeEvents.accepted(api, app_name)
         upgrade_url = "https://anaconda.com/pricing"
         console.print(f"Opening [cyan]{upgrade_url}[/cyan] in your browser...")
         webbrowser.open(upgrade_url)
+    else:
+        UpgradeEvents.dismissed(api, app_name)
 
 
 @app.callback(invoke_without_command=True)
@@ -484,7 +489,7 @@ def create_command(
         if "limit" in error_msg and "private" in error_msg:
             limit_value = _extract_limit_from_error(error)
             ChannelEvents.limit(api, app.info.name, channel_path=channel_path, action="create", limit=limit_value)
-            prompt_upgrade(limit_value)
+            _prompt_upgrade(api, app.info.name, limit_value)
         ChannelEvents.created(**event_kwargs)
         raise error
     if response.created:
@@ -649,7 +654,7 @@ def modify_command(
             if "limit" in error_msg and "private" in error_msg:
                 limit_value = _extract_limit_from_error(error)
                 ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
-                prompt_upgrade(limit_value)
+                _prompt_upgrade(api, app.info.name, limit_value)
         ChannelEvents.modified(api, app.info.name, channel_path=name, privacy=privacy, error=bool(error))
         if error:
             raise error

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -137,7 +137,7 @@ def _prompt_upgrade(api, app_name: Optional[str], limit: Optional[int], action: 
 
     if typer.confirm("\nWould you like to view upgrade options?", default=True):
         UpgradeEvents.accepted(api, app_name, action)
-        upgrade_url = "https://anaconda.com/pricing"
+        upgrade_url = api._pricing_page
         console.print(f"Opening [cyan]{upgrade_url}[/cyan] in your browser...")
         webbrowser.open(upgrade_url)
     else:

--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -9,6 +9,7 @@ import argparse
 import logging
 import os
 import re
+import webbrowser
 from glob import glob
 from typing import List, Optional, Tuple, cast
 
@@ -100,6 +101,18 @@ def _extract_limit_from_error(error: Exception) -> Optional[int]:
     """Extract channel limit number from error message."""
     limit_match = re.search(r'has reached the limit of (\d+)', str(error))
     return int(limit_match.group(1)) if limit_match else None
+
+
+def prompt_upgrade(limit: Optional[int]) -> None:
+    """Prompt user to upgrade when they hit the private channel limit."""
+    limit_text = f" of {limit}" if limit else ""
+    console.print(f"\n[yellow]You have reached the limit{limit_text} for private channels.[/yellow]")
+    console.print("Upgrade your plan to create more private channels.")
+
+    if typer.confirm("\nWould you like to view upgrade options?", default=True):
+        upgrade_url = "https://anaconda.com/pricing"
+        console.print(f"Opening [cyan]{upgrade_url}[/cyan] in your browser...")
+        webbrowser.open(upgrade_url)
 
 
 @app.callback(invoke_without_command=True)
@@ -471,6 +484,7 @@ def create_command(
         if "limit" in error_msg and "private" in error_msg:
             limit_value = _extract_limit_from_error(error)
             ChannelEvents.limit(api, app.info.name, channel_path=channel_path, action="create", limit=limit_value)
+            prompt_upgrade(limit_value)
         ChannelEvents.created(**event_kwargs)
         raise error
     if response.created:
@@ -635,6 +649,7 @@ def modify_command(
             if "limit" in error_msg and "private" in error_msg:
                 limit_value = _extract_limit_from_error(error)
                 ChannelEvents.limit(api, app.info.name, channel_path=name, action="modify", limit=limit_value)
+                prompt_upgrade(limit_value)
         ChannelEvents.modified(api, app.info.name, channel_path=name, privacy=privacy, error=bool(error))
         if error:
             raise error

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from anaconda_auth.client import BaseClient
 
-from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthorized
+from binstar_client.repocore.errors import InvalidName, RepoCoreError, Unauthenticated, Unauthorized
 from binstar_client.repocore.models import (
     Artifact,
     ArtifactFile,
@@ -153,7 +153,10 @@ class RepoCoreClient(BaseClient):
 
         msg = self._extract_error_message(response, action)
 
-        if response.status_code in (401, 403):
+        if response.status_code == 401:
+            return response_data, Unauthenticated(msg)
+
+        if response.status_code == 403:
             return response_data, Unauthorized(msg)
 
         return response_data, RepoCoreError(msg)

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 REPO_API_PATH = "/api/repo"
 AUTH_API_PATH = "/api/auth"
 ACCOUNT_API_PATH = "/api"
+PRICING_PAGE_PATH = "/pricing"
 
 
 class RepoCoreClient(BaseClient):
@@ -57,6 +58,10 @@ class RepoCoreClient(BaseClient):
     @property
     def _account_api_base(self):
         return self._base_uri + ACCOUNT_API_PATH
+
+    @property
+    def _pricing_page(self):
+        return self._base_uri + PRICING_PAGE_PATH
 
     @property
     def _channels_url(self):

--- a/binstar_client/repocore/errors.py
+++ b/binstar_client/repocore/errors.py
@@ -22,11 +22,18 @@ class RepoCoreError(Exception):
         )
 
 
+class Unauthenticated(RepoCoreError):
+    def __init__(self, message=None):
+        base_msg = message or "Authentication required"
+        separator = " " if base_msg.endswith(".") else ". "
+        self.msg = base_msg + separator + "You may need to run 'anaconda login'"
+        super().__init__(self.msg)
+
+
 class Unauthorized(RepoCoreError):
     def __init__(self, message=None):
         base_msg = message or "The provided token does not allow you to perform this operation"
-        separator = " " if base_msg.endswith(".") else ". "
-        self.msg = base_msg + separator + "You may need to run 'anaconda login'"
+        self.msg = base_msg
         super().__init__(self.msg)
 
 

--- a/binstar_client/repocore/telemetry.py
+++ b/binstar_client/repocore/telemetry.py
@@ -1,6 +1,6 @@
 import hashlib
 
-from anaconda_cli_base.telemetry import count as _base_count
+from anaconda_cli_base.telemetry import log_event
 
 from .telemetry_models import (
     TelemetryEvent,
@@ -94,7 +94,7 @@ def _check_account_attrs(api) -> Attributes:
     return api.account_attributes
 
 
-def _count(event: TelemetryEvent, api, app_name: str | None, error: bool = False) -> None:
+def _event(event: TelemetryEvent, api, app_name: str | None, error: bool = False) -> None:
     """Helper to track telemetry events with user attributes."""
     try:
         _check_error(event, error)
@@ -102,7 +102,7 @@ def _count(event: TelemetryEvent, api, app_name: str | None, error: bool = False
         all_attributes = {**user_attrs.to_dict(), **event.attribute_dump()}
         if app_name is None:
             app_name = ""
-        _base_count(event.event_name, app_name, attributes=all_attributes)
+        log_event("", event.event_name, app_name, all_attributes)
     except Exception:
         pass  # nosec B110
 
@@ -114,49 +114,49 @@ class ChannelEvents:
     def created(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track channel creation event."""
         event = ChannelCreatedEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)
 
     @staticmethod
     def created_exists(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track channel creation event when channel already exists."""
         event = ChannelCreatedExistsEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)
 
     @staticmethod
     def accessed(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track channel access event."""
         event = ChannelAccessedEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)
 
     @staticmethod
     def limit(api, app_name: str | None, **kwargs) -> None:
         """Track channel limit reached event."""
         event = ChannelLimitReachedEvent(**kwargs)
-        _count(event, api, app_name)
+        _event(event, api, app_name)
 
     @staticmethod
     def removed(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track channel removal event."""
         event = ChannelRemovedEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)
 
     @staticmethod
     def modified(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track channel modification event."""
         event = ChannelModifiedEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)
 
     @staticmethod
     def share(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track channel sharing event."""
         event = MemberInvitedEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)
 
     @staticmethod
     def unshare(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track channel unsharing event."""
         event = MemberRemovedEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)
 
 
 class UpgradeEvents:
@@ -166,19 +166,19 @@ class UpgradeEvents:
     def impressed(api, app_name: str | None) -> None:
         """Track upgrade prompt impression event."""
         event = UpgradePromptImpressedEvent()
-        _count(event, api, app_name)
+        _event(event, api, app_name)
 
     @staticmethod
     def accepted(api, app_name: str | None) -> None:
         """Track upgrade prompt acceptance event."""
         event = UpgradePromptAcceptedEvent()
-        _count(event, api, app_name)
+        _event(event, api, app_name)
 
     @staticmethod
     def dismissed(api, app_name: str | None) -> None:
         """Track upgrade prompt dismissal event."""
         event = UpgradePromptDismissedEvent()
-        _count(event, api, app_name)
+        _event(event, api, app_name)
 
 
 class UploadEvents:
@@ -188,4 +188,4 @@ class UploadEvents:
     def uploaded(api, app_name: str | None, error: bool = False, **kwargs) -> None:
         """Track package upload event."""
         event = PackageUploadedEvent(**kwargs)
-        _count(event, api, app_name, error)
+        _event(event, api, app_name, error)

--- a/binstar_client/repocore/telemetry.py
+++ b/binstar_client/repocore/telemetry.py
@@ -11,7 +11,7 @@ from .telemetry_models import (
     ChannelRemovedEvent,
     ChannelModifiedEvent,
     UpgradePromptImpressedEvent,
-    UpgradePromptConvertedEvent,
+    UpgradePromptAcceptedEvent,
     UpgradePromptDismissedEvent,
     PackageUploadedEvent,
     MemberInvitedEvent,
@@ -152,9 +152,9 @@ class UpgradeEvents:
         _count(event, api, app_name)
 
     @staticmethod
-    def converted(api, app_name: str | None) -> None:
-        """Track upgrade prompt conversion event."""
-        event = UpgradePromptConvertedEvent()
+    def accepted(api, app_name: str | None) -> None:
+        """Track upgrade prompt acceptance event."""
+        event = UpgradePromptAcceptedEvent()
         _count(event, api, app_name)
 
     @staticmethod

--- a/binstar_client/repocore/telemetry.py
+++ b/binstar_client/repocore/telemetry.py
@@ -16,6 +16,7 @@ from .telemetry_models import (
     PackageUploadedEvent,
     MemberInvitedEvent,
     MemberRemovedEvent,
+    CollaboratorLimitReachedEvent,
 )
 
 
@@ -158,26 +159,32 @@ class ChannelEvents:
         event = MemberRemovedEvent(**kwargs)
         _event(event, api, app_name, error)
 
+    @staticmethod
+    def collaborator_limit(api, app_name: str | None, **kwargs) -> None:
+        """Track collaborator limit reached event."""
+        event = CollaboratorLimitReachedEvent(**kwargs)
+        _event(event, api, app_name)
+
 
 class UpgradeEvents:
     """Upgrade prompt events"""
 
     @staticmethod
-    def impressed(api, app_name: str | None) -> None:
+    def impressed(api, app_name: str | None, action: str) -> None:
         """Track upgrade prompt impression event."""
-        event = UpgradePromptImpressedEvent()
+        event = UpgradePromptImpressedEvent(action=action)
         _event(event, api, app_name)
 
     @staticmethod
-    def accepted(api, app_name: str | None) -> None:
+    def accepted(api, app_name: str | None, action: str) -> None:
         """Track upgrade prompt acceptance event."""
-        event = UpgradePromptAcceptedEvent()
+        event = UpgradePromptAcceptedEvent(action=action)
         _event(event, api, app_name)
 
     @staticmethod
-    def dismissed(api, app_name: str | None) -> None:
+    def dismissed(api, app_name: str | None, action: str) -> None:
         """Track upgrade prompt dismissal event."""
-        event = UpgradePromptDismissedEvent()
+        event = UpgradePromptDismissedEvent(action=action)
         _event(event, api, app_name)
 
 

--- a/binstar_client/repocore/telemetry_models.py
+++ b/binstar_client/repocore/telemetry_models.py
@@ -80,10 +80,10 @@ class UpgradePromptImpressedEvent(TelemetryEvent):
     errorable: bool = False
 
 
-class UpgradePromptConvertedEvent(TelemetryEvent):
-    """Upgrade prompt conversion event."""
+class UpgradePromptAcceptedEvent(TelemetryEvent):
+    """Upgrade prompt acceptance event."""
 
-    event_name: str = "upgrade_prompt.converted"
+    event_name: str = "upgrade.accepted"
     errorable: bool = False
 
 

--- a/binstar_client/repocore/telemetry_models.py
+++ b/binstar_client/repocore/telemetry_models.py
@@ -80,6 +80,7 @@ class UpgradePromptImpressedEvent(TelemetryEvent):
 
     event_name: str = "upgrade_prompt.impressed"
     errorable: bool = False
+    action: str
 
 
 class UpgradePromptAcceptedEvent(TelemetryEvent):
@@ -87,6 +88,7 @@ class UpgradePromptAcceptedEvent(TelemetryEvent):
 
     event_name: str = "upgrade.accepted"
     errorable: bool = False
+    action: str
 
 
 class UpgradePromptDismissedEvent(TelemetryEvent):
@@ -94,6 +96,7 @@ class UpgradePromptDismissedEvent(TelemetryEvent):
 
     event_name: str = "upgrade_prompt.dismissed"
     errorable: bool = False
+    action: str
 
 
 class PackageUploadedEvent(TelemetryEvent):
@@ -123,3 +126,12 @@ class MemberRemovedEvent(TelemetryEvent):
     errorable: bool = True
     channel_path: str = Field(alias="channel.path")
     user: str
+
+
+class CollaboratorLimitReachedEvent(TelemetryEvent):
+    """Collaborator limit reached event."""
+
+    event_name: str = "collaborator.limit_reached"
+    errorable: bool = False
+    channel_path: str = Field(alias="channel.path")
+    action: str

--- a/binstar_client/repocore/telemetry_models.py
+++ b/binstar_client/repocore/telemetry_models.py
@@ -135,3 +135,4 @@ class CollaboratorLimitReachedEvent(TelemetryEvent):
     errorable: bool = False
     channel_path: str = Field(alias="channel.path")
     action: str
+    limit: Optional[int] = None

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -17,6 +17,7 @@ from binstar_client.repocore import (
 from binstar_client.repocore.errors import (
     InvalidName,
     RepoCoreError,
+    Unauthenticated,
     Unauthorized,
 )
 
@@ -362,14 +363,15 @@ class TestRepoCoreClientAPI:
         assert error is None
         assert result.changed is False
 
-    def test_manage_response_401_raises_unauthorized(self):
+    def test_manage_response_401_raises_unauthenticated(self):
         client = _make_client()
         mock_response = _mock_response(401, {"error": {"code": "auth_required", "message": "Invalid token"}})
 
         result, error = client._manage_response(mock_response, "test action")
         assert result == {"error": {"code": "auth_required", "message": "Invalid token"}}
-        assert isinstance(error, Unauthorized)
+        assert isinstance(error, Unauthenticated)
         assert "Invalid token" in str(error)
+        assert "anaconda login" in str(error)
 
     def test_manage_response_403(self):
         client = _make_client()
@@ -378,6 +380,7 @@ class TestRepoCoreClientAPI:
         result, error = client._manage_response(mock_response, "test action")
         assert result == {"message": "forbidden"}
         assert isinstance(error, Unauthorized)
+        assert "anaconda login" not in str(error)
 
     def test_manage_response_500(self):
         client = _make_client()
@@ -1142,7 +1145,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
-        mock_api.list_my_channels.side_effect = Unauthorized("Please run `anaconda login`.")
+        mock_api.list_my_channels.side_effect = Unauthenticated("Please run `anaconda login`.")
 
         aserver = MagicMock()
         aserver.user.return_value = {"login": "user1"}
@@ -1776,7 +1779,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_my_channels.return_value = _namespace_channels("testorg")
-        mock_api.upload_file.side_effect = Unauthorized()
+        mock_api.upload_file.side_effect = Unauthenticated()
 
         with (
             _patch_repo_api(mock_api),
@@ -1787,8 +1790,8 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert isinstance(result.exception, Unauthorized)
-        assert "does not allow you to perform this operation" in str(result.exception)
+        assert isinstance(result.exception, Unauthenticated)
+        assert "Authentication required" in str(result.exception)
         assert "anaconda login" in str(result.exception)
 
     def test_upload_repocore_error(self):
@@ -1829,7 +1832,7 @@ class TestRepoCoreChannelsCLI:
         app = _get_channels_app()
         mock_api = MagicMock()
         mock_api.list_my_channels.return_value = _namespace_channels("testorg")
-        mock_api.upload_file.side_effect = Unauthorized()
+        mock_api.upload_file.side_effect = Unauthenticated()
 
         with (
             _patch_repo_api(mock_api),
@@ -1840,8 +1843,8 @@ class TestRepoCoreChannelsCLI:
             result = runner.invoke(app, ["upload", "test-1.0-py39_0.conda", "--channel", "dev"])
 
         assert result.exit_code == 1
-        assert isinstance(result.exception, Unauthorized)
-        assert "does not allow you to perform this operation" in str(result.exception)
+        assert isinstance(result.exception, Unauthenticated)
+        assert "Authentication required" in str(result.exception)
         assert "anaconda login" in str(result.exception)
 
     def test_upload_error_response(self):

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -1474,6 +1474,38 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 1
         assert "At least one option is required" in result.output
 
+    def test_channels_modify_all_no_change(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
+        mock_api.update_channel.return_value = (ChannelUpdateResponse(changed=False), None)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["modify", "dev", "--privacy", "private", "--indexing-behavior", "default"])
+
+        assert result.exit_code == 0
+        assert "No change" in result.output
+        assert mock_api.update_channel.call_count == 2
+        mock_api.update_channel.assert_any_call("myorg/dev", privacy="private")
+        mock_api.update_channel.assert_any_call("myorg/dev", indexing_behavior="default")
+
+    def test_channels_modify_all_changed(self):
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myorg")
+        mock_api.update_channel.return_value = (ChannelUpdateResponse(changed=True), None)
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["modify", "dev", "--privacy", "private", "--indexing-behavior", "frozen"])
+
+        assert result.exit_code == 0
+        assert "Success" in result.output
+        assert mock_api.update_channel.call_count == 2
+        mock_api.update_channel.assert_any_call("myorg/dev", privacy="private")
+        mock_api.update_channel.assert_any_call("myorg/dev", indexing_behavior="frozen")
+
     def test_upload_single_file_with_explicit_channel(self):
         runner = CliRunner()
         app = _get_channels_app()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -12,6 +12,7 @@ from binstar_client.repocore.telemetry_models import (
     ChannelLimitReachedEvent,
     ChannelRemovedEvent,
     ChannelModifiedEvent,
+    CollaboratorLimitReachedEvent,
     MemberInvitedEvent,
     MemberRemovedEvent,
     PackageUploadedEvent,
@@ -61,12 +62,15 @@ class TestPydanticTelemetryModels:
         assert event.indexing_behavior == "frozen"
 
     def test_upgrade_events_models(self):
-        impressed = UpgradePromptImpressedEvent()
-        accepted = UpgradePromptAcceptedEvent()
-        dismissed = UpgradePromptDismissedEvent()
+        impressed = UpgradePromptImpressedEvent(action="create")
+        accepted = UpgradePromptAcceptedEvent(action="create")
+        dismissed = UpgradePromptDismissedEvent(action="create")
         assert impressed.event_name == "upgrade_prompt.impressed"
+        assert impressed.action == "create"
         assert accepted.event_name == "upgrade.accepted"
+        assert accepted.action == "create"
         assert dismissed.event_name == "upgrade_prompt.dismissed"
+        assert dismissed.action == "create"
 
     def test_package_uploaded_event_model(self):
         event = PackageUploadedEvent(channel="myorg/dev", package_type="conda", package_name="test-pkg")
@@ -86,6 +90,12 @@ class TestPydanticTelemetryModels:
         event = MemberRemovedEvent(channel_path="myorg/dev", user="testuser")
         assert event.event_name == "member.removed"
         assert event.channel_path == "myorg/dev"
+
+    def test_collaborator_limit_reached_event_model(self):
+        event = CollaboratorLimitReachedEvent(channel_path="myorg/dev", action="share")
+        assert event.event_name == "collaborator.limit_reached"
+        assert event.channel_path == "myorg/dev"
+        assert event.action == "share"
 
 
 class TestAttributes:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -97,6 +97,9 @@ class TestPydanticTelemetryModels:
         assert event.channel_path == "myorg/dev"
         assert event.action == "share"
 
+        event_with_limit = CollaboratorLimitReachedEvent(channel_path="myorg/dev", action="share", limit=5)
+        assert event_with_limit.limit == 5
+
 
 class TestAttributes:
     def test_attributes_with_valid_account(self):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -16,7 +16,7 @@ from binstar_client.repocore.telemetry_models import (
     MemberRemovedEvent,
     PackageUploadedEvent,
     TelemetryEvent,
-    UpgradePromptConvertedEvent,
+    UpgradePromptAcceptedEvent,
     UpgradePromptDismissedEvent,
     UpgradePromptImpressedEvent,
 )
@@ -62,10 +62,10 @@ class TestPydanticTelemetryModels:
 
     def test_upgrade_events_models(self):
         impressed = UpgradePromptImpressedEvent()
-        converted = UpgradePromptConvertedEvent()
+        accepted = UpgradePromptAcceptedEvent()
         dismissed = UpgradePromptDismissedEvent()
         assert impressed.event_name == "upgrade_prompt.impressed"
-        assert converted.event_name == "upgrade_prompt.converted"
+        assert accepted.event_name == "upgrade.accepted"
         assert dismissed.event_name == "upgrade_prompt.dismissed"
 
     def test_package_uploaded_event_model(self):


### PR DESCRIPTION
- adds upgrade prompt when users hit private channel limit
- max collaborators reached telemetry event added
- differentiates between unauthenticated and unauthorized errors
- adds dependency on anaconda-opentelemetry
- changes metric telemetry to logs