### PR TITLE
Add pypng fallback for png images if pillow is not installed

### DIFF
--- a/binstar_client/utils/image.py
+++ b/binstar_client/utils/image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 from typing import TYPE_CHECKING
 

--- a/binstar_client/utils/image.py
+++ b/binstar_client/utils/image.py
@@ -1,0 +1,88 @@
+import io
+from pathlib import Path
+
+import png
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None  # type: ignore
+
+from ..errors import PillowNotInstalled
+
+
+THUMB_SIZE = (340, 210)
+
+
+def resize_and_convert(path: str | Path) -> io.BytesIO:
+    """
+    Fits an image into a bounding box while preserving ratio.
+    If Pillow is not available, uses pypng for a simpler fallback.
+    """
+    path = Path(path)
+    if Image is None:
+        if path.suffix.lower() == ".png":
+            return _resize_and_convert_pypng(path)
+        raise PillowNotInstalled()
+    image = Image.open(path)
+    image.thumbnail(THUMB_SIZE)
+    out = io.BytesIO()
+    image.save(out, format='png')
+    out.seek(0)
+    # Comment this out to check written file
+    # with open("out-pillow.png", "wb") as f:
+    #     image.save(f, format="png")
+    return out
+
+
+def _resize_and_convert_pypng(path: str | Path) -> io.BytesIO:
+    """
+    pypng is pretty barebones when it comes to processing; it only
+    handles decoding and encoding for us. Everything else is done
+    needs to be done by hand on the pixel data.
+
+    Pillow's Image.thumbnail() resizes without distorion. IOW,
+    THUMB_SIZE is a bounding box. Pillow also defaults to bicubic
+    downsampling (prettier), here we are only doing nearest neighbor,
+    which is simpler but will result in less pretty outputs.
+    """
+    reader = png.Reader(filename=str(path))
+    width, height, rows, info = reader.read()
+    pixels = [list(row) for row in rows]
+    planes = info['planes']  # 3 for RGB, 4 for RGBA
+
+    x, y = THUMB_SIZE
+    if width <= x and height <= y:
+        # Already smaller, keep as is
+        new_width, new_height = width, height
+        scaled_pixels = pixels
+    else:
+        # Find dimensions in bounding box that preserve ratio
+        aspect = width / height
+        if x / y >= aspect:
+            new_width = int(round(y * aspect))
+            new_height = y
+        else:
+            new_width = x
+            new_height = int(round(x / aspect))
+
+        # downscale using nearest-neighbor
+        scaled_pixels = []
+        for out_y in range(new_height):
+            orig_y = int(out_y * height / new_height)
+            row = []
+            for out_x in range(new_width):
+                orig_x = int(out_x * width / new_width)
+                start = orig_x * planes
+                row.extend(pixels[orig_y][start : start + planes])
+            scaled_pixels.append(row)
+
+    out = io.BytesIO()
+    info.pop("size", None)
+    writer = png.Writer(width=new_width, height=new_height, **info)
+    writer.write(out, scaled_pixels)
+    out.seek(0)
+    # Comment this out to check written file
+    # with open("out-pypng.png", "wb") as f:
+    #     writer.write(f, scaled_pixels)
+    return out

--- a/binstar_client/utils/image.py
+++ b/binstar_client/utils/image.py
@@ -1,5 +1,10 @@
 import io
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from pathlib import Path
+    from typing import IO
 
 import png
 
@@ -14,7 +19,7 @@ from ..errors import PillowNotInstalled
 THUMB_SIZE = (340, 210)
 
 
-def resize_and_convert(path_or_buffer: str | Path | io.RawIOBase) -> io.BytesIO:
+def resize_and_convert(path_or_buffer: str | bytes | PathLike[str] | PathLike[bytes] | IO[bytes]) -> io.BytesIO:
     """
     Fits an image into a bounding box while preserving ratio.
     If Pillow is not available, uses pypng for a simpler fallback.

--- a/binstar_client/utils/image.py
+++ b/binstar_client/utils/image.py
@@ -14,17 +14,18 @@ from ..errors import PillowNotInstalled
 THUMB_SIZE = (340, 210)
 
 
-def resize_and_convert(path: str | Path) -> io.BytesIO:
+def resize_and_convert(path_or_buffer: str | Path | io.RawIOBase) -> io.BytesIO:
     """
     Fits an image into a bounding box while preserving ratio.
     If Pillow is not available, uses pypng for a simpler fallback.
     """
-    path = Path(path)
     if Image is None:
-        if path.suffix.lower() == ".png":
-            return _resize_and_convert_pypng(path)
+        # For known .png paths, we can fallback to pypng
+        if isinstance(path_or_buffer, (str, Path)):
+            if str(path_or_buffer).lower().endswith(".png"):
+                return _resize_and_convert_pypng(path_or_buffer)
         raise PillowNotInstalled()
-    image = Image.open(path)
+    image = Image.open(path_or_buffer)
     image.thumbnail(THUMB_SIZE)
     out = io.BytesIO()
     image.save(out, format='png')

--- a/binstar_client/utils/notebook/data_uri.py
+++ b/binstar_client/utils/notebook/data_uri.py
@@ -6,22 +6,15 @@ from urllib.parse import urlparse
 
 import requests
 
-try:
-    from PIL import Image
-except ImportError:
-    Image = None  # type: ignore
-
 from ...errors import PillowNotInstalled
+from ..image import Image, resize_and_convert as _resize_and_convert
 
 from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
-
-THUMB_SIZE = (340, 210)
 
 
 @deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 class DataURIConverter:
     def __init__(self, location, data=None):
-        self.check_pillow_installed()
         self.location = location
         self.data = data
 
@@ -47,14 +40,7 @@ class DataURIConverter:
         return b64
 
     def resize_and_convert(self, file):
-        if Image is None:
-            raise PillowNotInstalled()
-        image = Image.open(file)
-        image.thumbnail(THUMB_SIZE)
-        out = io.BytesIO()
-        image.save(out, format='png')
-        out.seek(0)
-        return out
+        return _resize_and_convert(file)
 
     def is_py3(self):
         return sys.version_info[0] == 3

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - urllib3 >=1.26.4
     - anaconda-cli-base >=0.9.1
     - anaconda-auth >=0.11.0
+    - pypng
 
 test:
   requires:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 conda-package-handling>=1.7.3
 defusedxml>=0.7.1
 nbformat>=4.4.0
+pypng
 python-dateutil>=2.6.1
 pytz>=2021.3
 pyyaml>=3.12


### PR DESCRIPTION
Closes #923 

Samples:

Original input
<img width="400" height="400" alt="37169284" src="https://github.com/user-attachments/assets/772e0337-c7fc-4c76-9ca4-edb4ed31a449" />

Pillow:
<img width="210" height="210" alt="out-pillow" src="https://github.com/user-attachments/assets/1f770275-af86-42e8-a770-fea1b5ff058e" />

PyPNG:
<img width="210" height="210" alt="out-pypng" src="https://github.com/user-attachments/assets/f1d63b9e-1884-4390-9320-0da4efe20b7d" />
