### PR TITLE
prompt users to create an org through the UI rather than automatically doing it

### DIFF
--- a/binstar_client/commands/_repo_channels.py
+++ b/binstar_client/commands/_repo_channels.py
@@ -29,6 +29,7 @@ from binstar_client.repocore.telemetry import ChannelEvents, UploadEvents
 from binstar_client.repocore.package_utils import PackageType, determine_package_type, windows_glob
 from binstar_client.repocore.resolve import (
     classify_and_resolve,
+    namespace_known_to_user as _namespace_known_to_user,
     resolve_channels_with_namespaces as _resolve_channels_with_namespaces,
     resolve_namespace_and_channel as _resolve_namespace_and_channel,
     resolve_no_namespace as _resolve_no_namespace,
@@ -470,6 +471,14 @@ def create_command(
 
     api = ctx.obj.repo_api
     resolved = _resolve_namespace_and_channel(api, name, namespace, require_namespace=False)
+
+    if resolved.namespace and not _namespace_known_to_user(api, resolved.namespace):
+        console.print(
+            f"[yellow]Namespace '{resolved.namespace}' doesn't exist yet.[/yellow]\n"
+            f"Create it at: [cyan]{api.create_namespace_url()}[/cyan] "
+            "(you'll already be signed in), then re-run this command."
+        )
+        raise typer.Exit(1)
 
     if public:
         privacy = "public"

--- a/binstar_client/repocore/client.py
+++ b/binstar_client/repocore/client.py
@@ -271,6 +271,16 @@ class RepoCoreClient(BaseClient):
             return [], error
         return [Channel(**item) for item in (data or {}).get("items", [])], None
 
+    def create_namespace_url(self) -> str:
+        """Web URL to create a brand-new namespace (an anaconda.com organization).
+
+        The CLI never auto-creates a namespace on the user's behalf (aside from
+        the reserved per-username namespace); this is where a user is sent to
+        create one explicitly first. Uses the same base URL the client's API
+        calls resolve to, so it honors ``--site``/``--at``.
+        """
+        return join(self._base_uri, "app", "organizations", "create")
+
     def create_namespace_channel(
         self, channel_name: str, namespace: Optional[str] = None, privacy: str = "private"
     ) -> tuple[Optional[ChannelCreationResponse], Optional[Exception]]:

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -136,6 +136,46 @@ def resolve_no_namespace(api, name: str) -> ResolvedChannel:
     return _repo_channel(namespace=None, channel_name=name)
 
 
+def namespace_known_to_user(api, namespace: str) -> bool:
+    """Whether ``namespace`` already exists for the caller.
+
+    "Known" means creating a channel under it cannot cause the repocore
+    backend to silently provision a brand-new namespace behind the user's
+    back. A namespace counts as known when it is:
+      * the caller's own username — the sanctioned exception (repocore
+        reserves this automatically for book-keeping/subscriptions), or
+      * returned by ``list_user_organizations`` (the caller is already a
+        member), or
+      * the namespace of a channel the caller can already write to (it
+        exists even if it doesn't surface via org membership, e.g. a
+        channel shared from an org the caller isn't a member of).
+
+    Best-effort: any lookup failure counts as "not known", so callers err
+    toward requiring explicit namespace creation rather than risking an
+    unintended auto-created namespace.
+    """
+    try:
+        username = (api.account.get("user") or {}).get("username") or ""
+    except Exception:
+        username = ""
+    if username and namespace == username:
+        return True
+
+    try:
+        if namespace in {org.name for org in api.list_user_organizations()}:
+            return True
+    except Exception:
+        pass
+
+    try:
+        if namespace in _writable_namespaces(list(_iter_writable_channels(api))):
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
 def resolve_namespace_and_channel(
     api, name: str, namespace: Optional[str] = None, require_namespace: bool = True
 ) -> ResolvedChannel:

--- a/binstar_client/repocore/resolve.py
+++ b/binstar_client/repocore/resolve.py
@@ -165,13 +165,13 @@ def namespace_known_to_user(api, namespace: str) -> bool:
         if namespace in {org.name for org in api.list_user_organizations()}:
             return True
     except Exception:
-        pass
+        pass  # nosec B110
 
     try:
         if namespace in _writable_namespaces(list(_iter_writable_channels(api))):
             return True
     except Exception:
-        pass
+        pass  # nosec B110
 
     return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ urllib3>=1.26.4
 anaconda-auth>=0.11.0
 anaconda-cli-base>=0.9.1
 # click 8.5.0 deprecates click.utils.get_binary_stream, which typer<0.26.0 still imports
-click<8.5
+click==8.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ tqdm>=4.56.0
 urllib3>=1.26.4
 anaconda-auth>=0.11.0
 anaconda-cli-base>=0.9.1
+# click 8.5.0 deprecates click.utils.get_binary_stream, which typer<0.26.0 still imports
+click<8.5

--- a/tests/test_repocore.py
+++ b/tests/test_repocore.py
@@ -210,6 +210,16 @@ class TestRepoCoreClientAPI:
         assert result == []
         assert isinstance(result, list)
 
+    def test_create_namespace_url(self):
+        client = _make_client()
+        client._base_uri = "https://anaconda.com"
+        assert client.create_namespace_url() == "https://anaconda.com/app/organizations/create"
+
+    def test_create_namespace_url_honors_base_uri(self):
+        client = _make_client()
+        client._base_uri = "https://repo.example.com"
+        assert client.create_namespace_url() == "https://repo.example.com/app/organizations/create"
+
     def test_list_all_channels(self):
         client = _make_client()
         payload = {
@@ -793,6 +803,53 @@ class TestResolveNamespaceAndChannel:
         assert resolved.namespace is None
         assert resolved.channel_name == "dev"
 
+    def test_namespace_known_own_username(self):
+        from binstar_client.repocore.resolve import namespace_known_to_user
+
+        mock_api = MagicMock()
+        mock_api.account.get.return_value = {"username": "testuser"}
+
+        assert namespace_known_to_user(mock_api, "testuser") is True
+
+    def test_namespace_known_org_membership(self):
+        from binstar_client.repocore.resolve import namespace_known_to_user
+
+        mock_api = MagicMock()
+        mock_api.account.get.return_value = {"username": "testuser"}
+        mock_api.list_user_organizations.return_value = [Namespace(name="my-team")]
+
+        assert namespace_known_to_user(mock_api, "my-team") is True
+
+    def test_namespace_known_writable_channel(self):
+        from binstar_client.repocore.resolve import namespace_known_to_user
+
+        mock_api = MagicMock()
+        mock_api.account.get.return_value = {"username": "testuser"}
+        mock_api.list_user_organizations.return_value = []
+        mock_api.list_my_channels.return_value = _namespace_channels("shared-org")
+
+        assert namespace_known_to_user(mock_api, "shared-org") is True
+
+    def test_namespace_unknown(self):
+        from binstar_client.repocore.resolve import namespace_known_to_user
+
+        mock_api = MagicMock()
+        mock_api.account.get.return_value = {"username": "testuser"}
+        mock_api.list_user_organizations.return_value = []
+        mock_api.list_my_channels.return_value = _namespace_channels()
+
+        assert namespace_known_to_user(mock_api, "brand-new-org") is False
+
+    def test_namespace_unknown_lookup_failures_swallowed(self):
+        from binstar_client.repocore.resolve import namespace_known_to_user
+
+        mock_api = MagicMock()
+        mock_api.account.get.side_effect = Exception("API Error")
+        mock_api.list_user_organizations.side_effect = Exception("API Error")
+        mock_api.list_my_channels.side_effect = Exception("API Error")
+
+        assert namespace_known_to_user(mock_api, "brand-new-org") is False
+
     def test_no_namespaces_require_false(self):
         from binstar_client.commands._repo_channels import _resolve_namespace_and_channel
 
@@ -1191,6 +1248,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="myns/dev", status_code=201),
             None,
@@ -1209,6 +1267,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="myns/dev", status_code=201),
             None,
@@ -1263,6 +1322,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="myns/dev", status_code=201),
             None,
@@ -1283,6 +1343,7 @@ class TestRepoCoreChannelsCLI:
         runner = CliRunner()
         app = _get_channels_app()
         mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels("myns")
         mock_api.create_namespace_channel.return_value = (
             ChannelCreationResponse(channel_path="myns/dev", status_code=201),
             None,
@@ -1310,6 +1371,62 @@ class TestRepoCoreChannelsCLI:
         assert result.exit_code == 1
         assert "mutually exclusive" in result.output
         mock_api.create_namespace_channel.assert_not_called()
+
+    def test_channels_create_unknown_namespace_flag_blocks(self):
+        """A --namespace that doesn't exist is not auto-created; the user is
+        pointed at the web UI instead."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels()
+        mock_api.list_user_organizations.return_value = []
+        type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
+        mock_api.create_namespace_url.return_value = "https://anaconda.com/app/organizations/create"
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "dev", "--namespace", "neworg", "--public"])
+
+        assert result.exit_code == 1
+        assert "Namespace 'neworg' doesn't exist yet." in result.output
+        assert "https://anaconda.com/app/organizations/create" in result.output
+        mock_api.create_namespace_channel.assert_not_called()
+
+    def test_channels_create_unknown_namespace_slash_blocks(self):
+        """A namespace/channel slash form for a nonexistent namespace is not
+        auto-created; the user is pointed at the web UI instead."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels()
+        mock_api.list_user_organizations.return_value = []
+        type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
+        mock_api.create_namespace_url.return_value = "https://anaconda.example.com/app/organizations/create"
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "neworg/dev", "--public"])
+
+        assert result.exit_code == 1
+        assert "Namespace 'neworg' doesn't exist yet." in result.output
+        assert "https://anaconda.example.com/app/organizations/create" in result.output
+        mock_api.create_namespace_channel.assert_not_called()
+
+    def test_channels_create_unknown_namespace_does_not_say_organization(self):
+        """The block message avoids the word 'organization' in prose (the URL
+        path itself legitimately contains it as the app's fixed route)."""
+        runner = CliRunner()
+        app = _get_channels_app()
+        mock_api = MagicMock()
+        mock_api.list_my_channels.return_value = _namespace_channels()
+        mock_api.list_user_organizations.return_value = []
+        type(mock_api).account = PropertyMock(return_value={"user": {"username": "testuser"}})
+        mock_api.create_namespace_url.return_value = "https://anaconda.com/app/organizations/create"
+
+        with _patch_repo_api(mock_api):
+            result = runner.invoke(app, ["create", "neworg/dev", "--public"])
+
+        assert result.exit_code == 1
+        prose = result.output.replace("https://anaconda.com/app/organizations/create", "")
+        assert "organization" not in prose
 
     def test_channels_create_no_namespaces_no_username(self):
         runner = CliRunner()


### PR DESCRIPTION
Organizations should be created through the UI: https://anaconda.atlassian.net/browse/RAD-271

Users can create private channels under their username. The automatic organization creation was added to try to prevent friction for the user. But using their own username (or existing organization) handles the situation better. 